### PR TITLE
collapse leading whitespace into a single tab

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,7 +284,9 @@ func (c *checker) Visit(node ast.Node) ast.Visitor {
 
 	if unchecked {
 		pos := c.fset.Position(call.Lparen)
-		c.errors = append(c.errors, uncheckedErr{pos, c.files[pos.Filename].lines[pos.Line-1]})
+		line := bytes.TrimSpace(c.files[pos.Filename].lines[pos.Line-1])
+		line = append([]byte{'\t'}, line...)
+		c.errors = append(c.errors, uncheckedErr{pos, line})
 	}
 	return c
 }


### PR DESCRIPTION
As discussed previously, remove leading whitespace. We add a single \t to improve output.
