### PR TITLE
Fix for API and URL update to go.exp

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func typeCheck(fset *token.FileSet, astFiles []*ast.File) (map[*ast.CallExpr]typ
 		Ident:  identFn,
 		Import: importer,
 	}
-	_, err := context.Check("FIX LINE 201", fset, astFiles...) // FIXME Not sure what to put as new 1st arg to Context.Check
+	_, err := context.Check(astFiles[0].Name.Name, fset, astFiles...)
 	return callTypes, identObjs, err
 }
 


### PR DESCRIPTION
code.google.com/p/go.exp/go/types -> code.google.com/p/go.tools/go/types
code.google.com/p/go.exp/go/exact -> code.google.com/p/go.tools/go/exact

Also, the API of go/types has changed, so this patch allows errcheck
to compile. The code appears to work correctly, but I'm not 100% sure,
and there are some FIXMEs that should be resolved.
