### PR TITLE
Finer-grained ignore syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,35 @@ argument:
 
 There are currently three flags: `-ignore`, `-ignorepkg` and `-blank`
 
-The `-ignore` flag takes a regular expression of function names to ignore.
+The `-ignore` flag takes a comma-separated list of pairs of the form package:regex.
+For each package, the regex describes which functions to ignore within that package.
+The package may be omitted to have the regex apply to all packages.
+
 For example, you may wish to ignore common operations like Read and Write:
 
     errcheck -ignore '[rR]ead|[wW]rite' path/to/package
 
+or you may wish to ignore common functions like the `print` variants in `fmt`:
+
+    errcheck -ignore 'fmt:[FS]?[Pp]rint*' path/to/package
+
 The `-ignorepkg` flag takes a comma-separated list of package import paths
-to ignore. By default the `fmt` package is ignored, so you should include
-it in your list if you want the default behavior:
+to ignore:
 
     errcheck -ignorepkg 'fmt,encoding/binary' path/to/package
+
+Note that this is equivalent to:
+
+    errcheck -ignore 'fmt:.*,encoding/binary:.*' path/to/package
+
+If a regex is provided for a package `pkg` via `-ignore`, and `pkg` also appears
+in the list of packages passed to `-ignorepkg`, the latter takes precedence;
+that is, all functions within `pkg` will be ignored.
+
+Note that by default the `fmt` package is ignored entirely, unless a regex is
+specified for it. To disable this, specify a regex that matches nothing:
+
+    errcheck -ignore 'fmt:a^' path/to/package
 
 The `-blank` flag enables checking for assignments of errors to the
 blank identifier. It takes no arguments.

--- a/main.go
+++ b/main.go
@@ -20,61 +20,63 @@ func Fatalf(s string, args ...interface{}) {
 	os.Exit(2)
 }
 
-// regexpFlag is a type that can be used with flag.Var for regular expression flags
-type regexpFlag struct {
-	re *regexp.Regexp
-}
+type ignoreFlag map[string]*regexp.Regexp
 
-func (r regexpFlag) String() string {
-	if r.re == nil {
-		return ""
+func (f ignoreFlag) String() string {
+	pairs := make([]string, 0, len(f))
+	for pkg, re := range f {
+		prefix := ""
+		if pkg != "" {
+			prefix = pkg + ":"
+		}
+		pairs = append(pairs, prefix + re.String())
 	}
-	return r.re.String()
+	return strings.Join(pairs, ",")
 }
 
-func (r *regexpFlag) Set(s string) error {
+func (f ignoreFlag) Set(s string) error {
 	if s == "" {
-		r.re = nil
 		return nil
 	}
-
-	re, err := regexp.Compile(s)
-	if err != nil {
-		return err
-	}
-	r.re = re
-	return nil
-}
-
-// stringsFlag is a type that can be used with flag.Var for lists that are turned to a set
-type stringsFlag struct {
-	items map[string]bool
-}
-
-func (f stringsFlag) String() string {
-	items := make([]string, 0, len(f.items))
-	for k := range f.items {
-		items = append(items, k)
-	}
-	return strings.Join(items, ",")
-}
-
-func (f *stringsFlag) Set(s string) error {
-	f.items = make(map[string]bool)
-	for _, item := range strings.Split(s, ",") {
-		f.items[item] = true
+	for _, pair := range strings.Split(s, ",") {
+		colonIndex := strings.Index(pair, ":")
+		var pkg, re string
+		if colonIndex == -1 {
+			pkg = ""
+			re = pair
+		} else {
+			pkg = pair[:colonIndex]
+			re = pair[colonIndex+1:]
+		}
+		regex, err := regexp.Compile(re)
+		if err != nil {
+			return err
+		}
+		f[pkg] = regex
 	}
 	return nil
 }
+
 
 func main() {
-	var ignore regexpFlag
-	flag.Var(&ignore, "ignore", "regular expression of function names to ignore")
-	ignorePkg := &stringsFlag{}
-	ignorePkg.Set("fmt")
-	flag.Var(ignorePkg, "ignorepkg", "comma-separated list of package paths to ignore")
+	dotStar := regexp.MustCompile(".*")
+
+	ignore := ignoreFlag(make(map[string]*regexp.Regexp))
+	flag.Var(ignore, "ignore", "comma-separated list of pairs of the form pkg:regex\n" +
+	                           "            the regex is used to ignore names within pkg")
+	ignorePkg := flag.String("ignorepkg", "", "comma-separated list of package paths to ignore")
 	blank := flag.Bool("blank", false, "if true, check for errors assigned to blank identifier")
 	flag.Parse()
+
+	for _, pkg := range strings.Split(*ignorePkg, ",") {
+		if pkg != "" {
+			ignore[pkg] = dotStar
+		}
+	}
+
+	if _, ok := ignore["fmt"]; !ok {
+		ignore["fmt"] = dotStar
+	}
 
 	pkgPath := flag.Arg(0)
 	if pkgPath == "" {
@@ -82,7 +84,7 @@ func main() {
 		Fatalf("you must specify a package")
 	}
 
-	if err := errcheck.CheckPackage(pkgPath, ignore.re, ignorePkg.items, *blank); err != nil {
+	if err := errcheck.CheckPackage(pkgPath, ignore, *blank); err != nil {
 		if e, ok := err.(errcheck.UncheckedErrors); ok {
 			for _, uncheckedError := range e.Errors {
 				fmt.Println(uncheckedError)


### PR DESCRIPTION
As discussed in #3. I ran into some edge cases you may want to comment on:
- If a regex is specified for a package, and that package is also specified in `-ignorepkg`, I discard the regex and ignore the whole package. (Could maybe output a warning for this.)
- If a global regex is specified, it's always checked first. So if a package regex is specified, a function is ignored if either the global regex or the package regex matches.
- About ignoring `fmt` by default. Currently `ignorepkg` has a default value of `fmt`. But I thought it would be awkward if someone specifies a package regex for `fmt`. Instead I special-case `fmt`, and ignore it if it's not specified with either flag; the way to disable this is to specify a match-nothing regex. This changes the old behavior; if you specify `-ignorepkg` without `fmt`, it could still be ignored.
