### PR TITLE
Use go.tools/importer instead of honnef.co/go/importer

### DIFF
--- a/lib/errcheck.go
+++ b/lib/errcheck.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// ErrNoGoFiles is returned when CheckPackage is run on a package with no Go source files
-	ErrNoGoFiles = errors.New("package contains no go source files")
+	ErrNoGoFiles = errors.New("package contains no (non-cgo) go source files")
 )
 
 // UncheckedErrors is returned from the CheckPackage function if the package contains


### PR DESCRIPTION
This pull request uses go.tools/importer and removes the dependency on honnef.co/go/importer. At the same time, parsing is greatly simplified, because go.tools/importer is doing everything for us.

This change affects errcheck's behaviour in two ways:
1. It can no longer use the gc importer for packages in GOROOT, which means it will have to parse the standard library on every run. This does add a small increase in run time and CPU usage. I don't see any way around this currently. `importer.SourceLoader` is required to return `[]*ast.File`, which implies parsing. And the documentation on `Context.Loader`, it being nil and that causing the gc importer to be used is irrelevant because the only way to import packages, `(*Importer).LoadPackage()` requires `Context.Loader` to be `!= nil`.
2. Programs using cgo fail differently now. Instead of failing on the `import "C"`, it will now skip over all Go files that use cgo, which means identifiers will be missing. Using those will lead to errors like `DestroyDatabase not declared by package levigo`.

Closes gh-26
Updates gh-16
