### PR TITLE
Upstream at go.tools changed Context to Config.

### DIFF
--- a/lib/errcheck.go
+++ b/lib/errcheck.go
@@ -98,7 +98,7 @@ func typeCheck(p package_) (typedPackage, error) {
 		Types:   tp.callTypes,
 		Objects: tp.identObjs,
 	}
-	context := types.Context{Import: importer.NewImporter().Import}
+	context := types.Config{Import: importer.NewImporter().Import}
 
 	_, err := context.Check(p.path, p.fset, p.astFiles, &info)
 	return tp, err


### PR DESCRIPTION
The guys at go.tools just changed types.Context to be types.Config. So here's a simple fix.

see: http://code.google.com/p/go/source/detail?repo=tools&r=5a9c2a38449e3b024dd12d98e2f33e686d9f95a0&spec=svn.tools.e5e9ae03f5d14c1eb1b6d4982e3ad33c9470a299#publish
