### PR TITLE
Update go-importer dependency.

### DIFF
--- a/lib/errcheck.go
+++ b/lib/errcheck.go
@@ -15,7 +15,7 @@ import (
 	"regexp"
 
 	"code.google.com/p/go.tools/go/types"
-	"honnef.co/go/importer"
+	"github.com/dominikh/go-importer"
 )
 
 var (


### PR DESCRIPTION
When I tried to `go get` the errcheck package, it gave me errors for `honnef.co/go/importer`.

I went to http://honnef.co/go/importer and the "Source" link pointed here:

https://github.com/dominikh/go-importer

I tried updating that package path and it seemed to work.
