### PR TITLE
Add -zero flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,15 @@ func Err(s string, args ...interface{}) {
 // Fatal calls Err followed by os.Exit(2)
 func Fatalf(s string, args ...interface{}) {
 	Err(s, args...)
-	os.Exit(2)
+	Exit(2)
+}
+
+// Exit calls os.Exit, sets code to 0 if zero flag is true
+func Exit(code int) {
+	if zero {
+		code = 0
+	}
+	os.Exit(code)
 }
 
 type ignoreFlag map[string]*regexp.Regexp
@@ -59,6 +67,7 @@ func (f ignoreFlag) Set(s string) error {
 }
 
 var dotStar = regexp.MustCompile(".*")
+var zero bool
 
 func main() {
 	ignore := ignoreFlag(map[string]*regexp.Regexp{
@@ -68,6 +77,7 @@ func main() {
 		"            the regex is used to ignore names within pkg")
 	ignorePkg := flag.String("ignorepkg", "", "comma-separated list of package paths to ignore")
 	blank := flag.Bool("blank", false, "if true, check for errors assigned to blank identifier")
+	flag.BoolVar(&zero, "zero", false, "if true, always exit with status 0")
 	flag.Parse()
 
 	for _, pkg := range strings.Split(*ignorePkg, ",") {
@@ -92,5 +102,5 @@ func main() {
 			Fatalf("failed to check package %s: %s", pkgPath, err)
 		}
 	}
-	os.Exit(exitStatus)
+	Exit(exitStatus)
 }


### PR DESCRIPTION
When the -zero flag is given, errcheck will always os.Exit with a status
code of 0.  This option is intended for use with Emacs' flycheck.  If a
checker command exit status != 0 and no messages apply to the current
buffer-file-name, flycheck emits the message:

  Checker %S returned non-zero exit code %s, but no errors from output:
  %s\nChecker definition probably flawed.

This can be common when using errcheck with flycheck, since errcheck
runs against the entire package, rather than a single file.
