### PR TITLE
optimization: use go/loader to load the entire set of packages/deps at once

### DIFF
--- a/lib/errcheck_test.go
+++ b/lib/errcheck_test.go
@@ -50,7 +50,7 @@ func init() {
 
 // TestUnchecked runs a test against the example files and ensures all unchecked errors are caught.
 func TestUnchecked(t *testing.T) {
-	err := CheckPackage("github.com/kisielk/errcheck/example", make(map[string]*regexp.Regexp), false)
+	err := CheckPackages([]string{"github.com/kisielk/errcheck/example"}, make(map[string]*regexp.Regexp), false)
 	uerr, ok := err.(UncheckedErrors)
 	if !ok {
 		t.Fatal("wrong error type returned")
@@ -80,7 +80,7 @@ func TestUnchecked(t *testing.T) {
 
 // TestBlank is like TestUnchecked but also ensures assignments to the blank identifier are caught.
 func TestBlank(t *testing.T) {
-	err := CheckPackage("github.com/kisielk/errcheck/example", make(map[string]*regexp.Regexp), true)
+	err := CheckPackages([]string{"github.com/kisielk/errcheck/example"}, make(map[string]*regexp.Regexp), true)
 	uerr, ok := err.(UncheckedErrors)
 	if !ok {
 		t.Fatal("wrong error type returned")

--- a/main.go
+++ b/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/kisielk/errcheck/lib"
-	"github.com/kisielk/gotool"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/kisielk/errcheck/lib"
+	"github.com/kisielk/gotool"
 )
 
 // Err prints an error to Stderr
@@ -76,21 +77,18 @@ func main() {
 		}
 	}
 
-	var exitStatus int
-	for _, pkgPath := range gotool.ImportPaths(flag.Args()) {
-		if err := errcheck.CheckPackage(pkgPath, ignore, *blank); err != nil {
-			if e, ok := err.(errcheck.UncheckedErrors); ok {
-				for _, uncheckedError := range e.Errors {
-					fmt.Println(uncheckedError)
-				}
-				exitStatus = 1
-				continue
-			} else if err == errcheck.ErrNoGoFiles {
-				fmt.Fprintln(os.Stderr, err)
-				continue
+	var pkgPaths = gotool.ImportPaths(flag.Args())
+	if err := errcheck.CheckPackages(pkgPaths, ignore, *blank); err != nil {
+		if e, ok := err.(errcheck.UncheckedErrors); ok {
+			for _, uncheckedError := range e.Errors {
+				fmt.Println(uncheckedError)
 			}
-			Fatalf("failed to check package %s: %s", pkgPath, err)
+			os.Exit(1)
+		} else if err == errcheck.ErrNoGoFiles {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(0)
 		}
+		Fatalf("failed to check package: %s", err)
 	}
-	os.Exit(exitStatus)
+	os.Exit(0)
 }


### PR DESCRIPTION
This removes a bunch of code that does a similar job to go/loader and takes the time required to errcheck my 47 packages from 46 seconds to 2.5 seconds.
