### PR TITLE
fix non error assignment to blank

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -12,6 +12,11 @@ func b() (int, error) {
 	return 0, nil
 }
 
+func c() int {
+	fmt.Println("this function returns an int") // UNCHECKED
+	return 7
+}
+
 func rec() {
 	defer func() {
 		recover()     // UNCHECKED
@@ -46,6 +51,9 @@ func main() {
 	// Additional cases for assigning errors to blank identifier
 	z, _ := b()    // BLANK
 	_, w := a(), 5 // BLANK
+
+	// Assign non error to blank identifier
+	_ = c()
 
 	_ = z + w // Avoid complaints about unused variables
 

--- a/lib/errcheck.go
+++ b/lib/errcheck.go
@@ -145,7 +145,7 @@ func (c *checker) errorsByArg(call *ast.CallExpr) []bool {
 		}
 		return s
 	}
-	return nil
+	return []bool{false}
 }
 
 func (c *checker) callReturnsError(call *ast.CallExpr) bool {


### PR DESCRIPTION
Fixes  index array out of range panic when checking  blank assignments and code assigns non error to blank:

```
panic: runtime error: index out of range [recovered]
    panic: runtime error: index out of range
goroutine 156 [running]:
runtime.panic(0x671e00, 0x80a29c)
    /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
testing.func·006()
    /usr/local/go/src/pkg/testing/testing.go:416 +0x176
runtime.panic(0x671e00, 0x80a29c)
    /usr/local/go/src/pkg/runtime/panic.c:248 +0x18d
github.com/foubarre/errcheck/lib.(*checker).Visit(0xc2098fa240, 0x7f7f2f9aab78, 0xc208fb7180, 0x0, 0x0)
    /h/g/go/src/github.com/foubarre/errcheck/lib/errcheck.go:233 +0x583
go/ast.Walk(0x7f7f2f9aa8e8, 0xc2098fa240, 0x7f7f2f9aab78, 0xc208fb7180)
    /usr/local/go/src/pkg/go/ast/walk.go:52 +0x58
go/ast.walkStmtList(0x7f7f2f9aa8e8, 0xc2098fa240, 0xc208dc9e00, 0x13, 0x20)
    /usr/local/go/src/pkg/go/ast/walk.go:32 +0xd1
go/ast.Walk(0x7f7f2f9aa8e8, 0xc2098fa240, 0x7f7f2fcdc260, 0xc2088dd1a0)
    /usr/local/go/src/pkg/go/ast/walk.go:224 +0x41e7
```
