### PR TITLE
Optionally detect unchecked type assertions

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -57,6 +57,20 @@ func main() {
 
 	_ = z + w // Avoid complaints about unused variables
 
+	// Type assertions
+	var i interface{}
+	s1 := i.(string)    // UNCHECKED
+	s1 = i.(string)     // UNCHECKED
+	s2, _ := i.(string) // BLANK
+	s2, _ = i.(string)  // BLANK
+	s3, ok := i.(string)
+	s3, ok = i.(string)
+	switch s4 := i.(type) {
+	case string:
+		_ = s4
+	}
+	_, _, _, _ = s1, s2, s3, ok
+
 	// Goroutine
 	go a()    // UNCHECKED
 	defer a() // UNCHECKED

--- a/lib/errcheck_test.go
+++ b/lib/errcheck_test.go
@@ -50,7 +50,7 @@ func init() {
 
 // TestUnchecked runs a test against the example files and ensures all unchecked errors are caught.
 func TestUnchecked(t *testing.T) {
-	err := CheckPackages([]string{"github.com/kisielk/errcheck/example"}, make(map[string]*regexp.Regexp), false)
+	err := CheckPackages([]string{"github.com/kisielk/errcheck/example"}, make(map[string]*regexp.Regexp), false, true)
 	uerr, ok := err.(UncheckedErrors)
 	if !ok {
 		t.Fatal("wrong error type returned")
@@ -80,7 +80,7 @@ func TestUnchecked(t *testing.T) {
 
 // TestBlank is like TestUnchecked but also ensures assignments to the blank identifier are caught.
 func TestBlank(t *testing.T) {
-	err := CheckPackages([]string{"github.com/kisielk/errcheck/example"}, make(map[string]*regexp.Regexp), true)
+	err := CheckPackages([]string{"github.com/kisielk/errcheck/example"}, make(map[string]*regexp.Regexp), true, true)
 	uerr, ok := err.(UncheckedErrors)
 	if !ok {
 		t.Fatal("wrong error type returned")

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 		"            the regex is used to ignore names within pkg")
 	ignorePkg := flag.String("ignorepkg", "", "comma-separated list of package paths to ignore")
 	blank := flag.Bool("blank", false, "if true, check for errors assigned to blank identifier")
+	types := flag.Bool("types", false, "if true, check for ignored type assertion results")
 	flag.Parse()
 
 	for _, pkg := range strings.Split(*ignorePkg, ",") {
@@ -78,7 +79,7 @@ func main() {
 	}
 
 	var pkgPaths = gotool.ImportPaths(flag.Args())
-	if err := errcheck.CheckPackages(pkgPaths, ignore, *blank); err != nil {
+	if err := errcheck.CheckPackages(pkgPaths, ignore, *blank, *types); err != nil {
 		if e, ok := err.(errcheck.UncheckedErrors); ok {
 			for _, uncheckedError := range e.Errors {
 				fmt.Println(uncheckedError)


### PR DESCRIPTION
Not sure this is the best way to go about it but I needed to detect unchecked type assertions and piggybacking on your great errcheck tool was the easiest way as I already use it anyway.
I added a -types option to detect unchecked type assertions, and it takes into account -blank as well.
Let me know what you think.
