### PR TITLE
always use the latest Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,1 @@
 language: go
-
-go:
-  - 1.2
-  - tip


### PR DESCRIPTION
While waiting for Travis to checkout #51 I noticed that Go 1.3 is not tested. I think it is better to just test the latest version.
