### PR TITLE
Check packages concurrently

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func Err(s string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "error: "+s+"\n", args...)
 }
 
-// Fatal calls Err followed by os.Exit(2)
+// Fatalf calls Err followed by os.Exit(2)
 func Fatalf(s string, args ...interface{}) {
 	Err(s, args...)
 	os.Exit(2)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/kisielk/errcheck/lib"
@@ -62,6 +63,8 @@ func (f ignoreFlag) Set(s string) error {
 var dotStar = regexp.MustCompile(".*")
 
 func main() {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
 	ignore := ignoreFlag(map[string]*regexp.Regexp{
 		"fmt": dotStar,
 	})


### PR DESCRIPTION
I think this can be done rather straight forward. My only concern is runtime.GOMAXPROCS. Is it OK to set runtime.GOMAXPROCS this way?

I tested this on a project with ~100 Go files and ~13k lines of code. Went from ~1.0s to ~0.6s. Most of the time is spent in /loader even if all files are in the cache. In my example 0.5s of the 0.6.s is spent there.