### PR TITLE
Make main testable

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	saveStderr := os.Stderr
+	saveStdout := os.Stdout
+	saveCwd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Cannot receive current directory: %v", err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Errorf("Cannot create pipe: %v", err)
+	}
+
+	os.Stderr = w
+	os.Stdout = w
+
+	bufChannel := make(chan string)
+
+	go func() {
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, r)
+		r.Close()
+		if err != nil {
+			t.Errorf("Cannot copy to buffer: %v", err)
+		}
+
+		bufChannel <- buf.String()
+	}()
+
+	exitCode := mainCmd([]string{"cmd name", "github.com/kisielk/errcheck/testdata"})
+
+	w.Close()
+
+	os.Stderr = saveStderr
+	os.Stdout = saveStdout
+	os.Chdir(saveCwd)
+
+	out := <-bufChannel
+
+	if exitCode != exitUncheckedError {
+		t.Errorf("Exit code is %d, expected %d", exitCode, exitUncheckedError)
+	}
+
+	expectUnchecked := 9
+	if got := strings.Count(out, "UNCHECKED"); got != expectUnchecked {
+		t.Errorf("Got %d UNCHECKED errors, expected %d in:\n%s", got, expectUnchecked, out)
+	}
+}


### PR DESCRIPTION
The main of errcheck is untested which is never a good think. I made it testable by putting the whole main into its own function which can be called with arguments. I find this approach much better than what the Go guys are doing with most cmds e.g. https://github.com/golang/tools/blob/master/cmd/vet/vet_test.go that is building the binary during the test and then executing it as an external command. I hope you agree.

This PR does not test every feature of the main. It is basically just a smoke test. But we could put it in a function and then test every scenario if you like. However, to be honest,  I am personally not that interested in doing that myself :whale: 