### PR TITLE
Improve argument parsing.

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,8 +81,9 @@ func mainCmd(args []string) int {
 		}
 	}
 
-	var pkgPaths = gotool.ImportPaths(flags.Args())
-	if err := errcheck.CheckPackages(pkgPaths, ignore, *blank, *asserts); err != nil {
+	// ImportPaths normalizes paths and expands '...'
+	var expandedArgs = gotool.ImportPaths(flags.Args())
+	if err := errcheck.CheckPackages(expandedArgs, ignore, *blank, *asserts); err != nil {
 		if e, ok := err.(errcheck.UncheckedErrors); ok {
 			for _, uncheckedError := range e.Errors {
 				fmt.Println(uncheckedError)


### PR DESCRIPTION
Now supports relative paths like './foo' and './...'

Also supports .go filenames provided the given files constitute an
entire package (so 'errcheck *.go' will work; 'errcheck foo.go' will
not if it depends on other files in its directory).

Fixes #45.