### PR TITLE
Remove deprecated upstream ImportFromBinary field.

### DIFF
--- a/internal/errcheck.go
+++ b/internal/errcheck.go
@@ -88,8 +88,7 @@ func (c *Checker) CheckPackages(paths ...string) error {
 		ctx.BuildTags = append(ctx.BuildTags, tag)
 	}
 	loadcfg := loader.Config{
-		ImportFromBinary: false,
-		Build:            &ctx,
+		Build: &ctx,
 	}
 	rest, err := loadcfg.FromArgs(paths, true)
 	if err != nil {


### PR DESCRIPTION
It is removed upstream in golang/tools@9c57c19a58835b00c0e3e283952087842242e49b.

A spiritual successor to #63.

Caveat: I made this PR by hand using [GitHub Flow](https://github.com/blog/1557-github-flow-in-the-browser), so I haven't tested that it compiles, is `gofmt`ed, or if there are additional issues to fix.