### PR TITLE
Use build tags while loading the import package list too

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/build"
 	"os"
 	"regexp"
 	"runtime"
@@ -123,13 +124,18 @@ func parseFlags(checker *errcheck.Checker, args []string) ([]string, int) {
 		return nil, exitFatalError
 	}
 
-	checker.Tags = []string(tags)
+	checker.Tags = tags
 	for _, pkg := range strings.Split(*ignorePkg, ",") {
 		if pkg != "" {
 			ignore[pkg] = dotStar
 		}
 	}
 	checker.Ignore = ignore
+
+	ctx := gotool.Context{
+		BuildContext: build.Default,
+	}
+	ctx.BuildContext.BuildTags = tags
 
 	// ImportPaths normalizes paths and expands '...'
 	return gotool.ImportPaths(flags.Args()), exitCodeOk


### PR DESCRIPTION
This relates to https://github.com/kisielk/gotool/pull/6

errcheck support build tages but this does not apply to the "..." pattern if the build tags are not forwarded to the loading of the import list.