### PR TITLE
Add ignoretests flag to disable checking of `_test.go` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,23 @@ errcheck is a program for checking for unchecked errors in go programs.
 
     go get github.com/kisielk/errcheck
 
-errcheck requires Go 1.4 and depends on the go/types package from the golang.org/x/tools repository.
+errcheck requires Go 1.4 and depends on the packages go/loader and go/types from the golang.org/x/tools repository.
 
 ## Use
 
-For basic usage, just give the package path of interest as the first
-argument:
+For basic usage, just give the package path of interest as the first argument:
 
     errcheck github.com/kisielk/errcheck/testdata
 
-There are currently five flags: `-ignore`, `-ignorepkg`, `-tags`, `-asserts`, and `-blank`
+To check all packages beneath the current directory:
+
+    errcheck ./...
+
+Or check all packages in your $GOPATH and $GOROOT:
+
+    errcheck all
+
+Additionally, the following flags are available.
 
 The `-ignore` flag takes a comma-separated list of pairs of the form package:regex.
 For each package, the regex describes which functions to ignore within that package.
@@ -50,7 +57,8 @@ specified for it. To disable this, specify a regex that matches nothing:
 
     errcheck -ignore 'fmt:a^' path/to/package
 
-The `-ignoretests` flag disables checking of `_test.go` files.
+The `-ignoretests` flag disables checking of `_test.go` files. It takes
+no arguments.
 
 The `-tags` flag takes a space-separated list of build tags, just like `go
 build`. If you are using any custom build tags in your code base, you may need
@@ -61,18 +69,6 @@ takes no arguments.
 
 The `-blank` flag enables checking for assignments of errors to the
 blank identifier. It takes no arguments.
-
-An example of using errcheck to check the go standard library packages:
-
-    errcheck -ignore 'Close|[wW]rite.*|Flush|Seek|[rR]ead.*' std > stdlibcheck
-
-Or check all packages in your $GOPATH and $GOROOT:
-
-    errcheck all > allcheck
-
-To check all packages beneath the current directory:
-
-    errcheck ./...
 
 ## Cgo
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ specified for it. To disable this, specify a regex that matches nothing:
 
     errcheck -ignore 'fmt:a^' path/to/package
 
+The `-ignoretests` flag disables checking of `_test.go` files.
+
 The `-tags` flag takes a space-separated list of build tags, just like `go
 build`. If you are using any custom build tags in your code base, you may need
 to specify the relevant tags here.
 
-The `-asserts` flag enabled checking for ignored type assertion results. It
+The `-asserts` flag enables checking for ignored type assertion results. It
 takes no arguments.
 
 The `-blank` flag enables checking for assignments of errors to the

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -94,6 +94,9 @@ type Checker struct {
 	Tags []string
 
 	Verbose bool
+
+	// If true, checking of of _test.go files is disabled
+	WithoutTests bool
 }
 
 func (c *Checker) logf(msg string, args ...interface{}) {
@@ -111,7 +114,7 @@ func (c *Checker) CheckPackages(paths ...string) error {
 	loadcfg := loader.Config{
 		Build: &ctx,
 	}
-	rest, err := loadcfg.FromArgs(paths, true)
+	rest, err := loadcfg.FromArgs(paths, !c.WithoutTests)
 	if err != nil {
 		return fmt.Errorf("could not parse arguments: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func parseFlags(checker *errcheck.Checker, args []string) ([]string, int) {
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flags.BoolVar(&checker.Blank, "blank", false, "if true, check for errors assigned to blank identifier")
 	flags.BoolVar(&checker.Asserts, "asserts", false, "if true, check for ignored type assertion results")
+	flags.BoolVar(&checker.WithoutTests, "ignoretests", false, "if true, checking of _test.go files is disabled")
 	flags.BoolVar(&checker.Verbose, "verbose", false, "produce more verbose logging")
 
 	flags.BoolVar(&abspath, "abspath", false, "print absolute paths to files")


### PR DESCRIPTION
Fixes #66 