### PR TITLE
Add -ignorecomment flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ specified for it. To disable this, specify a regex that matches nothing:
 The `-ignoretests` flag disables checking of `_test.go` files. It takes
 no arguments.
 
+The `-ignorecomment` flag takes a string that specifies a comment prefix to
+ignore. Any call with a comment that has has the prefix will be ignored. For
+example, `errcheck -ignorecomment ERRCHECK_IGNORE` will ignore the call:
+```go
+// ERRCHECK_IGNORE: ignore this error because it is always nil.
+funcThatReturnsAnError()
+```
+
 The `-tags` flag takes a space-separated list of build tags, just like `go
 build`. If you are using any custom build tags in your code base, you may need
 to specify the relevant tags here.

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -197,10 +197,14 @@ type visitor struct {
 func (v *visitor) ignoreComment(node ast.Node) bool {
 	// Get comment groups associated with the node.
 	cgroups := v.cmap[node]
-	// Return true if any comment group begins with "ERRCHECK_IGNORE".
+	// Return true if any comment begins with "ERRCHECK_IGNORE".
 	for _, cgroup := range cgroups {
-		if strings.HasPrefix(cgroup.Text(), "ERRCHECK_IGNORE") {
-			return true
+		for _, comm := range cgroup.List {
+			// Trim the leading "//" or "/*" and leading and trailing whitespace.
+			str := strings.TrimSpace(comm.Text[2:])
+			if strings.HasPrefix(str, "ERRCHECK_IGNORE") {
+				return true
+			}
 		}
 	}
 	return false

--- a/main.go
+++ b/main.go
@@ -134,6 +134,7 @@ func parseFlags(checker *errcheck.Checker, args []string) ([]string, int) {
 	})
 	flags.Var(ignore, "ignore", "comma-separated list of pairs of the form pkg:regex\n"+
 		"            the regex is used to ignore names within pkg")
+	flags.StringVar(&checker.IgnoreComment, "ignorecomment", "", "comment prefix that causes a call to be ignored")
 
 	if err := flags.Parse(args[1:]); err != nil {
 		return nil, exitFatalError


### PR DESCRIPTION
The `-ignorecomment` flag can be used to ignore calls that have a comment with a specified prefix. Comments are associated with nodes with an `ast.CommentMap`.

Here are some examples that will all be ignored with
`errcheck -asserts -ignorecomment ERRCHECK_IGNORE`
```go
// ERRCHECK_IGNORE: ignore this error because it is always nil.
aFuncThatReturnsAnError()

// This is a comment preceding the ignorecomment prefix.
// ERRCHECK_IGNORE: ignore this error because it is always nil.
aFuncThatReturnsAnError()

aFuncThatReturnsAnError() // ERRCHECK_IGNORE

// ERRCHECK_IGNORE works with defer.
defer aFuncThatReturnsAnError()

// ERRCHECK_IGNORE also works with type assertions.
str := anInterface.(string)
```

Any comment associated with a node can contain the prefix string. See the documentation for [ast.NewCommentMap](https://golang.org/pkg/go/ast/#NewCommentMap) for association rules.