### PR TITLE
Use 1.5+ go/types package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+go: 1.5.2
 sudo: false
 
 script:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ errcheck is a program for checking for unchecked errors in go programs.
 
     go get github.com/kisielk/errcheck
 
-errcheck requires Go 1.4 and depends on the packages go/loader and go/types from the golang.org/x/tools repository.
+errcheck requires Go 1.5 and depends on the package go/loader from the golang.org/x/tools repository.
 
 ## Use
 

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -16,8 +16,9 @@ import (
 	"strings"
 	"sync"
 
+	"go/types"
+
 	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
 )
 
 var errorType *types.Interface


### PR DESCRIPTION
We started noticing errcheck failures today. Switching to go/types seems
to fix the issue, but it will probably cause problems with 1.4.

Thoughts on this?

Fixes #87 