### PR TITLE
README: Suggest go get -u by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ errcheck is a program for checking for unchecked errors in go programs.
 
 ## Install
 
-    go get github.com/kisielk/errcheck
+    go get -u github.com/kisielk/errcheck
 
 errcheck requires Go 1.5 and depends on the package go/loader from the golang.org/x/tools repository.
 


### PR DESCRIPTION
Suggesting `go get -u` is a safer default. It results in a more predictable action, the user will end up with the latest version of `errcheck` and all its dependencies. Otherwise, the versions users end up with will be arbitrary, which may lead to issues. If users prefer not to update dependencies, they can always `go get` without `-u` flag.

As an example of the issue this would help resolve, see #92.