### PR TITLE
Add a trailing colon after the filename:line:col to match other tools.

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func reportUncheckedErrors(e *errcheck.UncheckedErrors) {
 				pos = newPos
 			}
 		}
-		fmt.Printf("%s\t%s\n", pos, uncheckedError.Line)
+		fmt.Printf("%s:\t%s\n", pos, uncheckedError.Line)
 	}
 }
 


### PR DESCRIPTION
Many (most?) tools emit errors and warnings in form:
~~~
  filename:line:	details
  filename:line:pos:	details
~~~
This makes errcheck consistent with those.  For me this means emacs'
'compilation-mode' recognizes these lines as warning/errors and I can
'next-error' correctly.