### PR TITLE
Ignore standard library methods that promise not to return a non nil error

### DIFF
--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -223,6 +223,17 @@ func (v *visitor) ignoreCall(call *ast.CallExpr) bool {
 		}
 	}
 
+	// Ignore standard library methods that promise not to return a non nil error
+	switch v.pkg.Uses[id].String() {
+	case
+		"func (*bytes.Buffer).Write(p []byte) (n int, err error)",
+		"func (*bytes.Buffer).WriteByte(c byte) error",
+		"func (*bytes.Buffer).WriteRune(r rune) (n int, err error)",
+		"func (*bytes.Buffer).WriteString(s string) (n int, err error)":
+
+		return true
+	}
+
 	return false
 }
 

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
 
 func a() error {
 	fmt.Println("this function returns an error") // UNCHECKED
@@ -124,4 +127,11 @@ func main() {
 	// Goroutine
 	go a()    // UNCHECKED
 	defer a() // UNCHECKED
+
+	// Ignore safe methods
+	buf := new(bytes.Buffer)
+	buf.Write(nil)
+	buf.WriteByte(0)
+	buf.WriteRune(0)
+	buf.WriteString("")
 }


### PR DESCRIPTION
Ignore unchecked errors from the following methods.

```
func (*bytes.Buffer).Write(p []byte) (n int, err error)
func (*bytes.Buffer).WriteByte(c byte) error
func (*bytes.Buffer).WriteRune(r rune) (n int, err error)
func (*bytes.Buffer).WriteString(s string) (n int, err error)
```
