### PR TITLE
Maintain a list of stdlib functions with irrelevant errors

### DIFF
--- a/testdata/main.go
+++ b/testdata/main.go
@@ -1,6 +1,11 @@
 package main
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	mrand "math/rand"
+)
 
 func a() error {
 	fmt.Println("this function returns an error") // UNCHECKED
@@ -124,4 +129,11 @@ func main() {
 	// Goroutine
 	go a()    // UNCHECKED
 	defer a() // UNCHECKED
+
+	b1 := bytes.Buffer{}
+	b2 := &bytes.Buffer{}
+	b1.Write(nil)
+	b2.Write(nil)
+	rand.Read(nil)
+	mrand.Read(nil)
 }


### PR DESCRIPTION
~~Either I don't understand the tests, or they're flawed. No matter what marker I did or did not place behind the newly added test cases, the tests always pass. They even pass when I removed the ignores and should've gotten more unchecked errors than expected.~~