### PR TITLE
Log the names of excluded and unchecked functions.

### DIFF
--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -34,8 +34,9 @@ var (
 
 // UncheckedError indicates the position of an unchecked error return.
 type UncheckedError struct {
-	Pos  token.Position
-	Line string
+	Pos      token.Position
+	Line     string
+	FuncName string
 }
 
 // UncheckedErrors is returned from the CheckPackage function if the package contains
@@ -216,15 +217,15 @@ type visitor struct {
 	errors []UncheckedError
 }
 
-func (v *visitor) excludeCall(call *ast.CallExpr) bool {
+func (v *visitor) fullName(call *ast.CallExpr) (string, bool) {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
-		return false
+		return "", false
 	}
 	fn, ok := v.pkg.ObjectOf(sel.Sel).(*types.Func)
 	if !ok {
 		// Shouldn't happen, but be paranoid
-		return false
+		return "", false
 	}
 	// The name is fully qualified by the import path, possible type,
 	// function/method name and pointer receiver.
@@ -233,8 +234,15 @@ func (v *visitor) excludeCall(call *ast.CallExpr) bool {
 	// thus not matching vendored standard library packages. If we
 	// want to support vendored stdlib packages, we need to implement
 	// FullName with our own logic.
-	name := fn.FullName()
-	return v.exclude[name]
+	return fn.FullName(), true
+}
+
+func (v *visitor) excludeCall(call *ast.CallExpr) bool {
+	if name, ok := v.fullName(call); ok {
+		return v.exclude[name]
+	}
+
+	return false
 }
 
 func (v *visitor) ignoreCall(call *ast.CallExpr) bool {
@@ -348,7 +356,7 @@ func (v *visitor) isRecover(call *ast.CallExpr) bool {
 	return false
 }
 
-func (v *visitor) addErrorAtPosition(position token.Pos) {
+func (v *visitor) addErrorAtPosition(position token.Pos, call *ast.CallExpr) {
 	pos := v.prog.Fset.Position(position)
 	lines, ok := v.lines[pos.Filename]
 	if !ok {
@@ -360,7 +368,13 @@ func (v *visitor) addErrorAtPosition(position token.Pos) {
 	if pos.Line-1 < len(lines) {
 		line = strings.TrimSpace(lines[pos.Line-1])
 	}
-	v.errors = append(v.errors, UncheckedError{pos, line})
+
+	var name string
+	if call != nil {
+		name, _ = v.fullName(call)
+	}
+
+	v.errors = append(v.errors, UncheckedError{pos, line, name})
 }
 
 func readfile(filename string) []string {
@@ -382,16 +396,16 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 	case *ast.ExprStmt:
 		if call, ok := stmt.X.(*ast.CallExpr); ok {
 			if !v.ignoreCall(call) && v.callReturnsError(call) {
-				v.addErrorAtPosition(call.Lparen)
+				v.addErrorAtPosition(call.Lparen, call)
 			}
 		}
 	case *ast.GoStmt:
 		if !v.ignoreCall(stmt.Call) && v.callReturnsError(stmt.Call) {
-			v.addErrorAtPosition(stmt.Call.Lparen)
+			v.addErrorAtPosition(stmt.Call.Lparen, stmt.Call)
 		}
 	case *ast.DeferStmt:
 		if !v.ignoreCall(stmt.Call) && v.callReturnsError(stmt.Call) {
-			v.addErrorAtPosition(stmt.Call.Lparen)
+			v.addErrorAtPosition(stmt.Call.Lparen, stmt.Call)
 		}
 	case *ast.AssignStmt:
 		if len(stmt.Rhs) == 1 {
@@ -409,7 +423,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 						// We shortcut calls to recover() because errorsByArg can't
 						// check its return types for errors since it returns interface{}.
 						if id.Name == "_" && (v.isRecover(call) || isError[i]) {
-							v.addErrorAtPosition(id.NamePos)
+							v.addErrorAtPosition(id.NamePos, call)
 						}
 					}
 				}
@@ -423,10 +437,10 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 				}
 				if len(stmt.Lhs) < 2 {
 					// assertion result not read
-					v.addErrorAtPosition(stmt.Rhs[0].Pos())
+					v.addErrorAtPosition(stmt.Rhs[0].Pos(), nil)
 				} else if id, ok := stmt.Lhs[1].(*ast.Ident); ok && v.blank && id.Name == "_" {
 					// assertion result ignored
-					v.addErrorAtPosition(id.NamePos)
+					v.addErrorAtPosition(id.NamePos, nil)
 				}
 			}
 		} else {
@@ -442,7 +456,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 							continue
 						}
 						if id.Name == "_" && v.callReturnsError(call) {
-							v.addErrorAtPosition(id.NamePos)
+							v.addErrorAtPosition(id.NamePos, call)
 						}
 					} else if assert, ok := stmt.Rhs[i].(*ast.TypeAssertExpr); ok {
 						if !v.asserts {
@@ -452,7 +466,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 							// Shouldn't happen anyway, no multi assignment in type switches
 							continue
 						}
-						v.addErrorAtPosition(id.NamePos)
+						v.addErrorAtPosition(id.NamePos, nil)
 					}
 				}
 			}


### PR DESCRIPTION
This change is intended to ease building an exclude file. It expands the program's verbose output in two ways:

- each line loaded from the exclude file is logged
- existing unchecked error's output includes the full function name

There is no change to behaviour when `-verbose` is not specified.

As I was unfamiliar with the string representation used for function types by Go's AST package it took me a while to land on the right configuration. In retrospect the correct usage is "obvious", but I figured having this output might save others some time :)

Here is an example of what the output looks like:

```console
$ errcheck -exclude .errignore -verbose ./src/rinq/amqp/internal/commandamqp
Excluding (github.com/rinq/rinq-go/src/rinq.Response).Fail
Checking github.com/rinq/rinq-go/src/rinq/amqp/internal/commandamqp
src/rinq/amqp/internal/commandamqp/invoker.go:448:10:	(github.com/rinq/rinq-go/vendor/github.com/streadway/amqp.Delivery).Ack	msg.Ack(false)
src/rinq/amqp/internal/commandamqp/invoker.go:450:13:	(github.com/rinq/rinq-go/vendor/github.com/streadway/amqp.Delivery).Reject	msg.Reject(false)
```