### PR TITLE
changes to allow the output of the results of checking a single file

### DIFF
--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -110,10 +110,10 @@ type Checker struct {
 	// If true, checking of _test.go files is disabled
 	WithoutTests bool
 
-	//Only check a single file
+	// Only check a single file
 	OnlyCheck string
 
-	//Extra output (to help distinguish output from other linters)
+	// Extra output (to help distinguish output from other linters)
 	Reason string
 
 	exclude map[string]bool


### PR DESCRIPTION
This PR has 2 small changes aimed at making errcheck useful in meta-linter tools. Added a flag (-only) to allow there linting of only a single file and added a flag (-reason) to add some text to the output to indicate that the issue is an unchecked error.