### PR TITLE
Exclude Write functions on strings.Builder

### DIFF
--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -127,6 +127,11 @@ func (c *Checker) SetExclude(l map[string]bool) {
 		"(*bytes.Buffer).WriteByte":   true,
 		"(*bytes.Buffer).WriteRune":   true,
 		"(*bytes.Buffer).WriteString": true,
+
+		"(*strings.Builder).Write":       true,
+		"(*strings.Builder).WriteByte":   true,
+		"(*strings.Builder).WriteRune":   true,
+		"(*strings.Builder).WriteString": true,
 	}
 	for k := range l {
 		c.exclude[k] = true


### PR DESCRIPTION
Go 1.10 added the [`strings.Builder`](https://godoc.org/strings#Builder) type which has the same semantics as `bytes.Buffer` for writes: they never return errors.