### PR TITLE
Check all levels of embedded interfaces against the exclude list.

### DIFF
--- a/internal/errcheck/embedded_walker.go
+++ b/internal/errcheck/embedded_walker.go
@@ -94,6 +94,11 @@ func getTypeAtFieldIndex(startingAt types.Type, fieldIndex int) types.Type {
 	return s.Field(fieldIndex).Type()
 }
 
+// getEmbeddedInterfaceDefiningMethod searches through any embedded interfaces of the
+// passed interface searching for one that defines the given function. If found, the
+// types.Named wrapping that interface will be returned along with true in the second value.
+//
+// If no such embedded interface is found, nil and false are returned.
 func getEmbeddedInterfaceDefiningMethod(interfaceT *types.Interface, fn *types.Func) (*types.Named, bool) {
 	for i := 0; i < interfaceT.NumEmbeddeds(); i++ {
 		embedded := interfaceT.Embedded(i)

--- a/internal/errcheck/embedded_walker.go
+++ b/internal/errcheck/embedded_walker.go
@@ -6,7 +6,8 @@ import (
 )
 
 // walkThroughEmbeddedInterfaces returns a slice of types that we need to walk through
-// in order to reach the actual interface definition of the function on the other end of this selection (x.f)
+// in order to reach the actual definition, in an interface, of the function on
+// the other end of this selection (x.f)
 //
 // False will be returned it:
 //   - the left side of the selection is not a function
@@ -48,10 +49,10 @@ func walkThroughEmbeddedInterfaces(sel *types.Selection) ([]types.Type, bool) {
 	// Now currentT is either a Struct implementing the
 	// actual function or an interface. If it's an interface,
 	// we need to continue digging until we find the interface
-	// that actually explicitly defines the function!
+	// that actually explicitly defines the function.
 	//
-	// If it's a Struct, we return false; we're only interested in interface-defined
-	// functions here.
+	// If it's a Struct, we return false, as we're only interested
+	// in interface-defined functions in this function.
 	_, ok = maybeUnname(currentT).(*types.Interface)
 	if !ok {
 		return nil, false

--- a/internal/errcheck/embedded_walker.go
+++ b/internal/errcheck/embedded_walker.go
@@ -1,0 +1,114 @@
+package errcheck
+
+import (
+	// "fmt"
+	"go/types"
+)
+
+// walkThroughEmbeddedInterfaces returns a slice of types that we need to walk through
+// in order to reach the actual interface definition of the function on the other end of this selection (x.f)
+//
+// False will be returned it:
+//   - the left side of the selection is not a function
+//   - the right side of the selection is an invalid type
+//   - we don't end at an interface-defined function
+//
+func walkThroughEmbeddedInterfaces(sel *types.Selection) ([]types.Type, bool) {
+	fn, ok := sel.Obj().(*types.Func)
+	if !ok {
+		return nil, false
+	}
+
+	currentT := sel.Recv()
+	if currentT == types.Typ[types.Invalid] {
+		return nil, false
+	}
+
+	// The first type is the immediate receiver itself
+	result := []types.Type{currentT}
+
+	// First, we can walk through any Struct fields provided
+	// by the selection Index() method.
+	indexes := sel.Index()
+	for _, fieldIndex := range indexes[:len(indexes)-1] {
+		currentT = maybeUnname(maybeDereference(currentT))
+
+		// Because we have an entry in Index for this type,
+		// we know it has to be a Struct.
+		s, ok := currentT.(*types.Struct)
+		if !ok {
+			panic("expected Struct!")
+		}
+
+		nextT := s.Field(fieldIndex).Type()
+		result = append(result, nextT)
+		currentT = nextT
+	}
+
+	// Now currentT is either a Struct implementing the
+	// actual function or an interface. If it's an interface,
+	// we need to continue digging until we find the interface
+	// that actually explicitly defines the function!
+	//
+	// If it's a Struct, we return false; we're only interested in interface-defined
+	// functions here.
+	_, ok = maybeUnname(currentT).(*types.Interface)
+	if !ok {
+		return nil, false
+	}
+
+	for {
+		interfaceT := maybeUnname(currentT).(*types.Interface)
+		if explicitlyDefinesMethod(interfaceT, fn) {
+			// then we're done
+			break
+		}
+
+		// otherwise, search through the embedded interfaces to find
+		// the one that defines this method.
+		for i := 0; i < interfaceT.NumEmbeddeds(); i++ {
+			nextNamedInterface := interfaceT.Embedded(i)
+			if definesMethod(maybeUnname(nextNamedInterface).(*types.Interface), fn) {
+				result = append(result, nextNamedInterface)
+				currentT = nextNamedInterface
+				break
+			}
+		}
+	}
+
+	return result, true
+}
+
+func explicitlyDefinesMethod(interfaceT *types.Interface, fn *types.Func) bool {
+	for i := 0; i < interfaceT.NumExplicitMethods(); i++ {
+		if interfaceT.ExplicitMethod(i).Id() == fn.Id() {
+			return true
+		}
+	}
+	return false
+}
+
+func definesMethod(interfaceT *types.Interface, fn *types.Func) bool {
+	for i := 0; i < interfaceT.NumMethods(); i++ {
+		if interfaceT.Method(i).Id() == fn.Id() {
+			return true
+		}
+	}
+	return false
+}
+
+func maybeDereference(t types.Type) types.Type {
+	p, ok := t.(*types.Pointer)
+	if ok {
+		return p.Elem()
+	}
+	return t
+}
+
+func maybeUnname(t types.Type) types.Type {
+	n, ok := t.(*types.Named)
+	if ok {
+		return n.Underlying()
+	}
+	return t
+}

--- a/internal/errcheck/embedded_walker_test.go
+++ b/internal/errcheck/embedded_walker_test.go
@@ -1,0 +1,93 @@
+package errcheck
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+const commonSrc = `
+package p
+
+type Inner struct {}
+func (Inner) Method()
+
+type Outer struct {Inner}
+type OuterP struct {*Inner}
+
+type InnerInterface interface {
+	Method()
+}
+
+type OuterInterface interface {InnerInterface}
+type MiddleInterfaceStruct struct {OuterInterface}
+type OuterInterfaceStruct struct {MiddleInterfaceStruct}
+
+var c = `
+
+type testCase struct {
+	selector   string
+	expectedOk bool
+	expected   []string
+}
+
+func TestWalkThroughEmbeddedInterfaces(t *testing.T) {
+	cases := []testCase{
+		testCase{"Inner{}.Method", false, nil},
+		testCase{"(&Inner{}).Method", false, nil},
+		testCase{"Outer{}.Method", false, nil},
+		testCase{"InnerInterface.Method", true, []string{"test.InnerInterface"}},
+		testCase{"OuterInterface.Method", true, []string{"test.OuterInterface", "test.InnerInterface"}},
+		testCase{"OuterInterfaceStruct.Method", true, []string{"test.OuterInterfaceStruct", "test.MiddleInterfaceStruct", "test.OuterInterface", "test.InnerInterface"}},
+	}
+
+	for _, c := range cases {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, "test", commonSrc+c.selector, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		conf := types.Config{}
+		info := types.Info{
+			Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		}
+		_, err = conf.Check("test", fset, []*ast.File{f}, &info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			s, ok := n.(*ast.SelectorExpr)
+			if ok {
+				selection, ok := info.Selections[s]
+				if !ok {
+					t.Fatalf("no Selection!")
+				}
+				ts, ok := walkThroughEmbeddedInterfaces(selection)
+				if ok != c.expectedOk {
+					t.Errorf("expected ok %v got %v", c.expectedOk, ok)
+					return false
+				}
+				if !ok {
+					return false
+				}
+
+				if len(ts) != len(c.expected) {
+					t.Fatalf("expected %d types, got %d", len(c.expected), len(ts))
+				}
+
+				for i, e := range c.expected {
+					if e != ts[i].String() {
+						t.Errorf("mismatch at index %d: expected %s got %s", i, e, ts[i])
+					}
+				}
+			}
+
+			return true
+		})
+
+	}
+
+}

--- a/internal/errcheck/embedded_walker_test.go
+++ b/internal/errcheck/embedded_walker_test.go
@@ -40,7 +40,7 @@ func TestWalkThroughEmbeddedInterfaces(t *testing.T) {
 		testCase{"Outer{}.Method", false, nil},
 		testCase{"InnerInterface.Method", true, []string{"test.InnerInterface"}},
 		testCase{"OuterInterface.Method", true, []string{"test.OuterInterface", "test.InnerInterface"}},
-		testCase{"OuterInterfaceStruct.Method", true, []string{"test.OuterInterfaceStruct", "test.MiddleInterfaceStruct", "test.OuterInterface", "test.InnerInterface"}},
+		testCase{"OuterInterfaceStruct.Method", true, []string{"test.OuterInterface", "test.InnerInterface"}},
 	}
 
 	for _, c := range cases {

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -239,6 +239,15 @@ type visitor struct {
 	errors []UncheckedError
 }
 
+// selectorAndFunc tries to get the selector and function from call expression.
+// For example, given the call expression representing "a.b()", the selector
+// is "a.b" and the function is "b" itself.
+//
+// The final return value will be true if it is able to do extract a selector
+// from the call and look up the function object it refers to.
+//
+// If the call does not include a selector (like if it is a plain "f()" function call)
+// then the final return value will be false.
 func (v *visitor) selectorAndFunc(call *ast.CallExpr) (*ast.SelectorExpr, *types.Func, bool) {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
@@ -255,29 +264,47 @@ func (v *visitor) selectorAndFunc(call *ast.CallExpr) (*ast.SelectorExpr, *types
 
 }
 
-func (v *visitor) fullName(call *ast.CallExpr) (string, bool) {
+// fullName will return a package / receiver-type qualified name for a called function
+// if the function is the result of a selector. Otherwise it will return
+// the empty string.
+//
+// The name is fully qualified by the import path, possible type,
+// function/method name and pointer receiver.
+//
+// For example,
+//   - for "fmt.Printf(...)" it will return "fmt.Printf"
+//   - for "base64.StdEncoding.Decode(...)" it will return "(*encoding/base64.Encoding).Decode"
+//   - for "myFunc()" it will return ""
+func (v *visitor) fullName(call *ast.CallExpr) string {
 	_, fn, ok := v.selectorAndFunc(call)
 	if !ok {
-		return "", false
+		return ""
 	}
-	// The name is fully qualified by the import path, possible type,
-	// function/method name and pointer receiver.
-	//
+
 	// TODO(dh): vendored packages will have /vendor/ in their name,
 	// thus not matching vendored standard library packages. If we
 	// want to support vendored stdlib packages, we need to implement
 	// FullName with our own logic.
-	return fn.FullName(), true
+	return fn.FullName()
 }
 
+// namesForExcludeCheck will return a list of fully-qualified function names
+// from a function call that can be used to check against the exclusion list.
+//
+// If a function call is against a local function (like "myFunc()") then no
+// names are returned. If the function is package-qualified (like "fmt.Printf()")
+// then just that function's fullName is returned.
+//
+// Otherwise, we walk through all the potentially embeddded interfaces of the receiver
+// the collect a list of type-qualified function names that we will check.
 func (v *visitor) namesForExcludeCheck(call *ast.CallExpr) []string {
 	sel, fn, ok := v.selectorAndFunc(call)
 	if !ok {
 		return nil
 	}
 
-	name, ok := v.fullName(call)
-	if !ok {
+	name := v.fullName(call)
+	if name == "" {
 		return nil
 	}
 
@@ -297,6 +324,10 @@ func (v *visitor) namesForExcludeCheck(call *ast.CallExpr) []string {
 
 	result := make([]string, len(ts))
 	for i, t := range ts {
+		// Like in fullName, vendored packages will have /vendor/ in their name,
+		// thus not matching vendored standard library packages. If we
+		// want to support vendored stdlib packages, we need to implement
+		// additional logic here.
 		result[i] = fmt.Sprintf("(%s).%s", t.String(), fn.Name())
 	}
 	return result
@@ -438,7 +469,7 @@ func (v *visitor) addErrorAtPosition(position token.Pos, call *ast.CallExpr) {
 
 	var name string
 	if call != nil {
-		name, _ = v.fullName(call)
+		name = v.fullName(call)
 	}
 
 	v.errors = append(v.errors, UncheckedError{pos, line, name})

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -256,7 +256,6 @@ func (v *visitor) fullName(call *ast.CallExpr) (string, bool) {
 	if !ok {
 		return "", false
 	}
-
 	// The name is fully qualified by the import path, possible type,
 	// function/method name and pointer receiver.
 	//
@@ -278,13 +277,15 @@ func (v *visitor) namesForExcludeCheck(call *ast.CallExpr) []string {
 		return nil
 	}
 
-	// This will have ok false for functions without a receiver type,
-	// so just return the functions full name.
+	// This will be missing for functions without a receiver (like fmt.Printf),
+	// so just fall back to the the function's fullName in that case.
 	selection, ok := v.pkg.Selections[sel]
 	if !ok {
 		return []string{name}
 	}
 
+	// This will return with ok false if the function isn't defined
+	// on an interface, so just fall back to the fullName.
 	ts, ok := walkThroughEmbeddedInterfaces(selection)
 	if !ok {
 		return []string{name}

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -143,12 +143,11 @@ func (c *Checker) SetExclude(l map[string]bool) {
 		"(*strings.Builder).WriteByte",
 		"(*strings.Builder).WriteRune",
 		"(*strings.Builder).WriteString",
+
+		// hash
+		"(hash.Hash).Write",
 	} {
 		c.exclude[exc] = true
-	}
-
-	for k := range l {
-		c.exclude[k] = true
 	}
 }
 
@@ -295,13 +294,11 @@ func (v *visitor) namesForExcludeCheck(call *ast.CallExpr) []string {
 	for i, t := range ts {
 		result[i] = fmt.Sprintf("(%s).%s", t.String(), fn.Name())
 	}
-	fmt.Printf("%v\n", ts)
 	return result
 }
 
 func (v *visitor) excludeCall(call *ast.CallExpr) bool {
 	for _, name := range v.namesForExcludeCheck(call) {
-		fmt.Printf("%v\n", name)
 		if v.exclude[name] {
 			return true
 		}

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -149,6 +149,10 @@ func (c *Checker) SetExclude(l map[string]bool) {
 	} {
 		c.exclude[exc] = true
 	}
+
+	for k := range l {
+		c.exclude[k] = true
+	}
 }
 
 func (c *Checker) logf(msg string, args ...interface{}) {

--- a/internal/errcheck/errcheck_test.go
+++ b/internal/errcheck/errcheck_test.go
@@ -187,6 +187,11 @@ func test(t *testing.T, f flags) {
 	checker := NewChecker()
 	checker.Asserts = asserts
 	checker.Blank = blank
+	checker.SetExclude(map[string]bool{
+		fmt.Sprintf("(%s.ErrorMakerWrapper).MakeNilError", testPackage):  true,
+		fmt.Sprintf("(*%s.ErrorMakerWrapper).MakeNilError", testPackage): true,
+		fmt.Sprintf("(%s.ErrorMaker).MakeAnotherNilError", testPackage):  true,
+	})
 	err := checker.CheckPackages(testPackage)
 	uerr, ok := err.(*UncheckedErrors)
 	if !ok {

--- a/internal/errcheck/errcheck_test.go
+++ b/internal/errcheck/errcheck_test.go
@@ -188,9 +188,7 @@ func test(t *testing.T, f flags) {
 	checker.Asserts = asserts
 	checker.Blank = blank
 	checker.SetExclude(map[string]bool{
-		fmt.Sprintf("(%s.ErrorMakerWrapper).MakeNilError", testPackage):  true,
-		fmt.Sprintf("(*%s.ErrorMakerWrapper).MakeNilError", testPackage): true,
-		fmt.Sprintf("(%s.ErrorMaker).MakeAnotherNilError", testPackage):  true,
+		fmt.Sprintf("(%s.ErrorMakerInterface).MakeNilError", testPackage): true,
 	})
 	err := checker.CheckPackages(testPackage)
 	uerr, ok := err.(*UncheckedErrors)

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -66,12 +66,12 @@ func customPointerErrorTuple() (int, *MyPointerError) {
 }
 
 // Test custom excludes
-type ErrorMaker struct{}
-
-func (ErrorMaker) MakeNilError() error        { return nil }
-func (ErrorMaker) MakeAnotherNilError() error { return nil }
-
-type ErrorMakerWrapper struct{ ErrorMaker }
+type ErrorMakerInterface interface {
+	MakeNilError() error
+}
+type ErrorMakerInterfaceWrapper interface {
+	ErrorMakerInterface
+}
 
 func main() {
 	// Single error return
@@ -148,15 +148,6 @@ func main() {
 
 	ioutil.ReadFile("main.go") // UNCHECKED
 
-	// We exclude (ErrorMakerWrapper).MakeNilError, but not
-	// (ErrorMaker).MakeNilError itself.
-	//
-	// We do exclude MakeAnotherNilError itself.
-	em := ErrorMaker{}
-	em.MakeNilError() // UNCHECKED
-	em.MakeAnotherNilError()
-	wem := ErrorMakerWrapper{ErrorMaker{}}
-	wem.MakeNilError()
-	(&wem).MakeNilError()
-	wem.MakeAnotherNilError()
+	var emiw ErrorMakerInterfaceWrapper
+	emiw.MakeNilError()
 }

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -65,6 +65,14 @@ func customPointerErrorTuple() (int, *MyPointerError) {
 	return 0, &e
 }
 
+// Test custom excludes
+type ErrorMaker struct{}
+
+func (ErrorMaker) MakeNilError() error        { return nil }
+func (ErrorMaker) MakeAnotherNilError() error { return nil }
+
+type ErrorMakerWrapper struct{ ErrorMaker }
+
 func main() {
 	// Single error return
 	_ = a() // BLANK
@@ -139,4 +147,16 @@ func main() {
 	mrand.Read(nil)
 
 	ioutil.ReadFile("main.go") // UNCHECKED
+
+	// We exclude (ErrorMakerWrapper).MakeNilError, but not
+	// (ErrorMaker).MakeNilError itself.
+	//
+	// We do exclude MakeAnotherNilError itself.
+	em := ErrorMaker{}
+	em.MakeNilError() // UNCHECKED
+	em.MakeAnotherNilError()
+	wem := ErrorMakerWrapper{ErrorMaker{}}
+	wem.MakeNilError()
+	(&wem).MakeNilError()
+	wem.MakeAnotherNilError()
 }

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -145,6 +146,7 @@ func main() {
 	b2.Write(nil)
 	rand.Read(nil)
 	mrand.Read(nil)
+	sha256.New().Write([]byte{})
 
 	ioutil.ReadFile("main.go") // UNCHECKED
 


### PR DESCRIPTION
This addresses https://github.com/kisielk/errcheck/issues/132 .

When generating names of a call to check against the exclusion list, errcheck currently just uses the name of the function itself. For example, for the Write call in

```
var h hash.Hash
h.Write([]byte{})
```

the checked name will be `(io.Writer).Write`. This limits the usefulness of the exclusion list, because we'd really like to be able to exclude `(hash.Hash).Write`, which is [documented](https://golang.org/pkg/hash/#Hash) to never return an error.

So this PR adds code (`embedded_walker.go`) to search through a `types.Selection` of a `types.Func`, recording all the interfaces that are passed through while descending down to the actual declaration of that Func. In the example above, we'd observe that we pass through two interfaces getting to `Write`: `hash.Hash` and `io.Writer`. It also deals the receiver being a struct with an embedded interface.

Then we use this code in `errcheck` to generate multiple names to check against the exclusion list: `["(hash.Hash).Write", "(io.Writer).Write"]` in this example.

And finally, the PR adds `(hash.Hash).Write` to the default exclusion list as a use case for all this code.