### PR TITLE
internal/errcheck: exclude F* stdlib printing variants

### DIFF
--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -131,8 +131,11 @@ func (c *Checker) SetExclude(l map[string]bool) {
 		// fmt
 		"fmt.Errorf",
 		"fmt.Print",
+		"fmt.Fprint",
 		"fmt.Printf",
+		"fmt.Fprintf",
 		"fmt.Println",
+		"fmt.Fprintln",
 
 		// math/rand
 		"math/rand.Read",


### PR DESCRIPTION
Signed-off-by: Gorka Lerchundi Osa <glertxundi@gmail.com>