### PR TITLE
Support go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.6"
-    - go: "1.7"
-    - go: "1.8"
     - go: "1.9"
     - go: "1.10"
     - go: "tip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 
 matrix:
   include:
+    - go: "1.7"
+    - go: "1.8"
     - go: "1.9"
     - go: "1.10"
     - go: "tip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.7"
-    - go: "1.8"
     - go: "1.9"
     - go: "1.10"
     - go: "tip"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ errcheck is a program for checking for unchecked errors in go programs.
 
     go get -u github.com/kisielk/errcheck
 
-errcheck requires Go 1.7 or newer and depends on the package go/packages from the golang.org/x/tools repository.
+errcheck requires Go 1.9 or newer and depends on the package go/packages from the golang.org/x/tools repository.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -94,14 +94,7 @@ no arguments.
 
 ## Cgo
 
-Currently errcheck is unable to check packages that `import "C"` due to limitations
-in the importer.
-
-However, you can use errcheck on packages that depend on those which use cgo. In
-order for this to work you need to `go install` the cgo dependencies before running
-errcheck on the dependent packages.
-
-See https://github.com/kisielk/errcheck/issues/16 for more details.
+Currently errcheck does not fully support type checking for packages that use cgo when used with versions of Go earlier than Go 1.11.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ errcheck is a program for checking for unchecked errors in go programs.
 
     go get -u github.com/kisielk/errcheck
 
-errcheck requires Go 1.6 or newer and depends on the package go/loader from the golang.org/x/tools repository.
+errcheck requires Go 1.6 or newer and depends on the package go/packages from the golang.org/x/tools repository.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ errcheck is a program for checking for unchecked errors in go programs.
 
     go get -u github.com/kisielk/errcheck
 
-errcheck requires Go 1.9 or newer and depends on the package go/packages from the golang.org/x/tools repository.
+errcheck requires Go 1.7 or newer and depends on the package go/packages from the golang.org/x/tools repository.
 
 ## Use
 
@@ -94,7 +94,7 @@ no arguments.
 
 ## Cgo
 
-Currently errcheck is unable to check packages that import "C" due to limitations in the importer.
+Currently errcheck is unable to check packages that import "C" due to limitations in the importer when used with versions earlier than Go 1.11.
 
 However, you can use errcheck on packages that depend on those which use cgo. In order for this to work you need to go install the cgo dependencies before running errcheck on the dependent packages.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ errcheck is a program for checking for unchecked errors in go programs.
 
     go get -u github.com/kisielk/errcheck
 
-errcheck requires Go 1.6 or newer and depends on the package go/packages from the golang.org/x/tools repository.
+errcheck requires Go 1.9 or newer and depends on the package go/packages from the golang.org/x/tools repository.
 
 ## Use
 
@@ -94,7 +94,11 @@ no arguments.
 
 ## Cgo
 
-Currently errcheck does not fully support type checking for packages that use cgo when used with versions of Go earlier than Go 1.11.
+Currently errcheck is unable to check packages that import "C" due to limitations in the importer.
+
+However, you can use errcheck on packages that depend on those which use cgo. In order for this to work you need to go install the cgo dependencies before running errcheck on the dependent packages.
+
+See https://github.com/kisielk/errcheck/issues/16 for more details.
 
 ## Exit Codes
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module "github.com/kisielk/errcheck"
+module github.com/kisielk/errcheck
 
 require (
-	"github.com/kisielk/gotool" v1.0.0
-	"golang.org/x/tools" v0.0.0-20180221164845-07fd8470d635
+	github.com/kisielk/gotool v1.0.0
+	golang.org/x/tools v0.0.0-20180730211359-0700b576e4d8
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
 module github.com/kisielk/errcheck
 
-require (
-	github.com/kisielk/gotool v1.0.0
-	golang.org/x/tools v0.0.0-20180730211359-0700b576e4d8
-)
+require golang.org/x/tools v0.0.0-20180730211359-0700b576e4d8

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kisielk/errcheck
 
-require golang.org/x/tools v0.0.0-20180730211359-0700b576e4d8
+require golang.org/x/tools v0.0.0-20180801205936-1801cb7c1535

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kisielk/errcheck
 
-require golang.org/x/tools v0.0.0-20180802195359-82515cf89538
+require golang.org/x/tools v0.0.0-20180803180156-3c07937fe18c

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kisielk/errcheck
 
-require golang.org/x/tools v0.0.0-20180801205936-1801cb7c1535
+require golang.org/x/tools v0.0.0-20180802195359-82515cf89538

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"go/build"
 	"go/token"
 	"go/types"
 	"os"
@@ -17,8 +16,7 @@ import (
 	"strings"
 	"sync"
 
-	"go/parser"
-	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/packages"
 )
 
 var errorType *types.Interface
@@ -165,28 +163,18 @@ func (c *Checker) logf(msg string, args ...interface{}) {
 	}
 }
 
-func (c *Checker) load(paths ...string) (*loader.Program, error) {
-	ctx := build.Default
-	for _, tag := range c.Tags {
-		ctx.BuildTags = append(ctx.BuildTags, tag)
-	}
-	loadcfg := loader.Config{
-		Build: &ctx,
-	}
+// loadPackages is used for testing.
+var loadPackages = func(cfg *packages.Config, paths ...string) ([]*packages.Package, error) {
+	return packages.Load(cfg, paths...)
+}
 
-	if c.WithoutGeneratedCode {
-		loadcfg.ParserMode = parser.ParseComments
+func (c *Checker) load(paths ...string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode:  packages.LoadAllSyntax,
+		Tests: !c.WithoutTests,
+		Flags: []string{fmt.Sprintf("-tags=%s", strings.Join(c.Tags, " "))},
 	}
-
-	rest, err := loadcfg.FromArgs(paths, !c.WithoutTests)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse arguments: %s", err)
-	}
-	if len(rest) > 0 {
-		return nil, fmt.Errorf("unhandled extra arguments: %v", rest)
-	}
-
-	return loadcfg.Load()
+	return loadPackages(cfg, paths...)
 }
 
 var generatedCodeRegexp = regexp.MustCompile("^// Code generated .* DO NOT EDIT\\.$")
@@ -209,27 +197,22 @@ func (c *Checker) shouldSkipFile(file *ast.File) bool {
 
 // CheckPackages checks packages for errors.
 func (c *Checker) CheckPackages(paths ...string) error {
-	program, err := c.load(paths...)
+	pkgs, err := c.load(paths...)
 	if err != nil {
 		return fmt.Errorf("could not type check: %s", err)
 	}
 
 	var wg sync.WaitGroup
 	u := &UncheckedErrors{}
-	for _, pkgInfo := range program.InitialPackages() {
-		if pkgInfo.Pkg.Path() == "unsafe" { // not a real package
-			continue
-		}
-
+	for _, pkg := range pkgs {
 		wg.Add(1)
 
-		go func(pkgInfo *loader.PackageInfo) {
+		go func(pkg *packages.Package) {
 			defer wg.Done()
-			c.logf("Checking %s", pkgInfo.Pkg.Path())
+			c.logf("Checking %s", pkg.Types.Path())
 
 			v := &visitor{
-				prog:    program,
-				pkg:     pkgInfo,
+				pkg:     pkg,
 				ignore:  c.Ignore,
 				blank:   c.Blank,
 				asserts: c.Asserts,
@@ -238,19 +221,28 @@ func (c *Checker) CheckPackages(paths ...string) error {
 				errors:  []UncheckedError{},
 			}
 
-			for _, astFile := range v.pkg.Files {
+			for _, astFile := range v.pkg.Syntax {
 				if c.shouldSkipFile(astFile) {
 					continue
 				}
 				ast.Walk(v, astFile)
 			}
 			u.Append(v.errors...)
-		}(pkgInfo)
+		}(pkg)
 	}
 
 	wg.Wait()
 	if u.Len() > 0 {
+		// Sort unchecked errors and remove duplicates. Duplicates may occur when a file
+		// containing an unchecked error belongs to > 1 package.
 		sort.Sort(byName{u})
+		uniq := u.Errors[:0] // compact in-place
+		for i, err := range u.Errors {
+			if i == 0 || err != u.Errors[i-1] {
+				uniq = append(uniq, err)
+			}
+		}
+		u.Errors = uniq
 		return u
 	}
 	return nil
@@ -258,8 +250,7 @@ func (c *Checker) CheckPackages(paths ...string) error {
 
 // visitor implements the errcheck algorithm
 type visitor struct {
-	prog    *loader.Program
-	pkg     *loader.PackageInfo
+	pkg     *packages.Package
 	ignore  map[string]*regexp.Regexp
 	blank   bool
 	asserts bool
@@ -284,7 +275,7 @@ func (v *visitor) selectorAndFunc(call *ast.CallExpr) (*ast.SelectorExpr, *types
 		return nil, nil, false
 	}
 
-	fn, ok := v.pkg.ObjectOf(sel.Sel).(*types.Func)
+	fn, ok := v.pkg.TypesInfo.ObjectOf(sel.Sel).(*types.Func)
 	if !ok {
 		// Shouldn't happen, but be paranoid
 		return nil, nil, false
@@ -340,7 +331,7 @@ func (v *visitor) namesForExcludeCheck(call *ast.CallExpr) []string {
 
 	// This will be missing for functions without a receiver (like fmt.Printf),
 	// so just fall back to the the function's fullName in that case.
-	selection, ok := v.pkg.Selections[sel]
+	selection, ok := v.pkg.TypesInfo.Selections[sel]
 	if !ok {
 		return []string{name}
 	}
@@ -401,7 +392,7 @@ func (v *visitor) ignoreCall(call *ast.CallExpr) bool {
 		return true
 	}
 
-	if obj := v.pkg.Uses[id]; obj != nil {
+	if obj := v.pkg.TypesInfo.Uses[id]; obj != nil {
 		if pkg := obj.Pkg(); pkg != nil {
 			if re, ok := v.ignore[pkg.Path()]; ok {
 				return re.MatchString(id.Name)
@@ -435,7 +426,7 @@ func nonVendoredPkgPath(pkgPath string) (string, bool) {
 // len(s) == number of return types of call
 // s[i] == true iff return type at position i from left is an error type
 func (v *visitor) errorsByArg(call *ast.CallExpr) []bool {
-	switch t := v.pkg.Types[call].Type.(type) {
+	switch t := v.pkg.TypesInfo.Types[call].Type.(type) {
 	case *types.Named:
 		// Single return
 		return []bool{isErrorType(t)}
@@ -477,7 +468,7 @@ func (v *visitor) callReturnsError(call *ast.CallExpr) bool {
 // isRecover returns true if the given CallExpr is a call to the built-in recover() function.
 func (v *visitor) isRecover(call *ast.CallExpr) bool {
 	if fun, ok := call.Fun.(*ast.Ident); ok {
-		if _, ok := v.pkg.Uses[fun].(*types.Builtin); ok {
+		if _, ok := v.pkg.TypesInfo.Uses[fun].(*types.Builtin); ok {
 			return fun.Name == "recover"
 		}
 	}
@@ -485,7 +476,7 @@ func (v *visitor) isRecover(call *ast.CallExpr) bool {
 }
 
 func (v *visitor) addErrorAtPosition(position token.Pos, call *ast.CallExpr) {
-	pos := v.prog.Fset.Position(position)
+	pos := v.pkg.Fset.Position(position)
 	lines, ok := v.lines[pos.Filename]
 	if !ok {
 		lines = readfile(pos.Filename)

--- a/internal/errcheck/errcheck.go
+++ b/internal/errcheck/errcheck.go
@@ -202,10 +202,10 @@ func (c *Checker) CheckPackages(paths ...string) error {
 	if err != nil {
 		return err
 	}
-	// Check for type check errors in the initial packages.
+	// Check for errors in the initial packages.
 	for _, pkg := range pkgs {
 		if len(pkg.Errors) > 0 {
-			return fmt.Errorf("errors while type checking package %s: %v", pkg.ID, pkg.Errors)
+			return fmt.Errorf("errors while loading package %s: %v", pkg.ID, pkg.Errors)
 		}
 	}
 

--- a/internal/errcheck/errcheck_test.go
+++ b/internal/errcheck/errcheck_test.go
@@ -2,9 +2,6 @@ package errcheck
 
 import (
 	"fmt"
-	"go/build"
-	"go/parser"
-	"go/token"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/packages"
 )
 
 const testPackage = "github.com/kisielk/errcheck/testdata"
@@ -40,28 +39,27 @@ func init() {
 	blankMarkers = make(map[marker]bool)
 	assertMarkers = make(map[marker]bool)
 
-	pkg, err := build.Import(testPackage, "", 0)
+	cfg := &packages.Config{
+		Mode: packages.LoadSyntax,
+	}
+	pkgs, err := packages.Load(cfg, testPackage)
 	if err != nil {
 		panic("failed to import test package")
 	}
-	fset := token.NewFileSet()
-	astPkg, err := parser.ParseDir(fset, pkg.Dir, nil, parser.ParseComments)
-	if err != nil {
-		panic("failed to parse test package")
-	}
-
-	for _, file := range astPkg["main"].Files {
-		for _, comment := range file.Comments {
-			text := comment.Text()
-			pos := fset.Position(comment.Pos())
-			m := marker{pos.Filename, pos.Line}
-			switch text {
-			case "UNCHECKED\n":
-				uncheckedMarkers[m] = true
-			case "BLANK\n":
-				blankMarkers[m] = true
-			case "ASSERT\n":
-				assertMarkers[m] = true
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Syntax {
+			for _, comment := range file.Comments {
+				text := comment.Text()
+				pos := pkg.Fset.Position(comment.Pos())
+				m := marker{pos.Filename, pos.Line}
+				switch text {
+				case "UNCHECKED\n":
+					uncheckedMarkers[m] = true
+				case "BLANK\n":
+					blankMarkers[m] = true
+				case "ASSERT\n":
+					assertMarkers[m] = true
+				}
 			}
 		}
 	}
@@ -95,14 +93,14 @@ func TestWhitelist(t *testing.T) {
 
 func TestIgnore(t *testing.T) {
 	const testVendorMain = `
-	package main
+package main
 
-	import "github.com/testlog"
+import "github.com/testlog"
 
-	func main() {
-		// returns an error that is not checked
-		testlog.Info()
-	}`
+func main() {
+	// returns an error that is not checked
+	testlog.Info()
+}`
 	const testLog = `
 	package testlog
 
@@ -115,12 +113,18 @@ func TestIgnore(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// copy testvendor directory into current directory for test
-	testVendorDir, err := ioutil.TempDir(".", "testvendor")
+	// copy testvendor directory into directory for test
+	tmpGopath, err := ioutil.TempDir("", "testvendor")
 	if err != nil {
 		t.Fatalf("unable to create testvendor directory: %v", err)
 	}
-	defer os.RemoveAll(testVendorDir)
+	testVendorDir := path.Join(tmpGopath, "src", "github.com/testvendor")
+	if err := os.MkdirAll(testVendorDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	defer func() {
+		os.RemoveAll(tmpGopath)
+	}()
 
 	if err := ioutil.WriteFile(path.Join(testVendorDir, "main.go"), []byte(testVendorMain), 0755); err != nil {
 		t.Fatalf("Failed to write testvendor main: %v", err)
@@ -144,7 +148,7 @@ func TestIgnore(t *testing.T) {
 		// ignoring vendored import works
 		{
 			ignore: map[string]*regexp.Regexp{
-				path.Join("github.com/kisielk/errcheck/internal/errcheck", testVendorDir, "vendor/github.com/testlog"): regexp.MustCompile("Info"),
+				path.Join("github.com/testvendor/vendor/github.com/testlog"): regexp.MustCompile("Info"),
 			},
 		},
 		// non-vendored path ignores vendored import
@@ -158,7 +162,15 @@ func TestIgnore(t *testing.T) {
 	for i, currCase := range cases {
 		checker := NewChecker()
 		checker.Ignore = currCase.ignore
-		err := checker.CheckPackages(path.Join("github.com/kisielk/errcheck/internal/errcheck", testVendorDir))
+
+		loadPackages = func(cfg *packages.Config, paths ...string) ([]*packages.Package, error) {
+			cfg.Env = append(os.Environ(), "GOPATH="+tmpGopath)
+			cfg.Dir = testVendorDir
+			pkgs, err := packages.Load(cfg, paths...)
+			return pkgs, err
+		}
+
+		err := checker.CheckPackages("github.com/testvendor")
 
 		if currCase.numExpectedErrs == 0 {
 			if err != nil {
@@ -202,12 +214,18 @@ func TestWithoutGeneratedCode(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// copy testvendor directory into current directory for test
-	testVendorDir, err := ioutil.TempDir(".", "testvendor")
+	// copy testvendor directory into directory for test
+	tmpGopath, err := ioutil.TempDir("", "testvendor")
 	if err != nil {
 		t.Fatalf("unable to create testvendor directory: %v", err)
 	}
-	defer os.RemoveAll(testVendorDir)
+	testVendorDir := path.Join(tmpGopath, "src", "github.com/testvendor")
+	if err := os.MkdirAll(testVendorDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	defer func() {
+		os.RemoveAll(tmpGopath)
+	}()
 
 	if err := ioutil.WriteFile(path.Join(testVendorDir, "main.go"), []byte(testVendorMain), 0755); err != nil {
 		t.Fatalf("Failed to write testvendor main: %v", err)
@@ -228,7 +246,7 @@ func TestWithoutGeneratedCode(t *testing.T) {
 			withoutGeneratedCode: false,
 			numExpectedErrs:      1,
 		},
-		// ignoring vendored import works
+		// ignoring generated code works
 		{
 			withoutGeneratedCode: true,
 			numExpectedErrs:      0,
@@ -238,7 +256,13 @@ func TestWithoutGeneratedCode(t *testing.T) {
 	for i, currCase := range cases {
 		checker := NewChecker()
 		checker.WithoutGeneratedCode = currCase.withoutGeneratedCode
-		err := checker.CheckPackages(path.Join("github.com/kisielk/errcheck/internal/errcheck", testVendorDir))
+		loadPackages = func(cfg *packages.Config, paths ...string) ([]*packages.Package, error) {
+			cfg.Env = append(os.Environ(), "GOPATH="+tmpGopath)
+			cfg.Dir = testVendorDir
+			pkgs, err := packages.Load(cfg, paths...)
+			return pkgs, err
+		}
+		err := checker.CheckPackages(path.Join("github.com/testvendor"))
 
 		if currCase.numExpectedErrs == 0 {
 			if err != nil {

--- a/internal/errcheck/errcheck_test.go
+++ b/internal/errcheck/errcheck_test.go
@@ -40,7 +40,8 @@ func init() {
 	assertMarkers = make(map[marker]bool)
 
 	cfg := &packages.Config{
-		Mode: packages.LoadSyntax,
+		Mode:  packages.LoadSyntax,
+		Tests: true,
 	}
 	pkgs, err := packages.Load(cfg, testPackage)
 	if err != nil {
@@ -93,14 +94,14 @@ func TestWhitelist(t *testing.T) {
 
 func TestIgnore(t *testing.T) {
 	const testVendorMain = `
-package main
+	package main
 
-import "github.com/testlog"
+	import "github.com/testlog"
 
-func main() {
-	// returns an error that is not checked
-	testlog.Info()
-}`
+	func main() {
+		// returns an error that is not checked
+		testlog.Info()
+	}`
 	const testLog = `
 	package testlog
 
@@ -162,14 +163,12 @@ func main() {
 	for i, currCase := range cases {
 		checker := NewChecker()
 		checker.Ignore = currCase.ignore
-
 		loadPackages = func(cfg *packages.Config, paths ...string) ([]*packages.Package, error) {
 			cfg.Env = append(os.Environ(), "GOPATH="+tmpGopath)
 			cfg.Dir = testVendorDir
 			pkgs, err := packages.Load(cfg, paths...)
 			return pkgs, err
 		}
-
 		err := checker.CheckPackages("github.com/testvendor")
 
 		if currCase.numExpectedErrs == 0 {

--- a/internal/errcheck/errcheck_test.go
+++ b/internal/errcheck/errcheck_test.go
@@ -42,6 +42,7 @@ func init() {
 	cfg := &packages.Config{
 		Mode:  packages.LoadSyntax,
 		Tests: true,
+		Error: func(error) {}, // don't print type check errors
 	}
 	pkgs, err := packages.Load(cfg, testPackage)
 	if err != nil {
@@ -180,7 +181,7 @@ func TestIgnore(t *testing.T) {
 
 		uerr, ok := err.(*UncheckedErrors)
 		if !ok {
-			t.Errorf("Case %d: wrong error type returned", i)
+			t.Errorf("Case %d: wrong error type returned: %v", i, err)
 			continue
 		}
 
@@ -272,7 +273,7 @@ func TestWithoutGeneratedCode(t *testing.T) {
 
 		uerr, ok := err.(*UncheckedErrors)
 		if !ok {
-			t.Errorf("Case %d: wrong error type returned", i)
+			t.Errorf("Case %d: wrong error type returned: %v", i, err)
 			continue
 		}
 
@@ -296,7 +297,7 @@ func test(t *testing.T, f flags) {
 	err := checker.CheckPackages(testPackage)
 	uerr, ok := err.(*UncheckedErrors)
 	if !ok {
-		t.Fatal("wrong error type returned")
+		t.Fatalf("wrong error type returned: %v", err)
 	}
 
 	numErrors := len(uncheckedMarkers)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/kisielk/errcheck/internal/errcheck"
-	"github.com/kisielk/gotool"
 )
 
 const (
@@ -133,7 +132,7 @@ func parseFlags(checker *errcheck.Checker, args []string) ([]string, int) {
 	flags.BoolVar(&checker.Blank, "blank", false, "if true, check for errors assigned to blank identifier")
 	flags.BoolVar(&checker.Asserts, "asserts", false, "if true, check for ignored type assertion results")
 	flags.BoolVar(&checker.WithoutTests, "ignoretests", false, "if true, checking of _test.go files is disabled")
-	flags.BoolVar(&checker.WithoutGeneratedCode,  "ignoregenerated", false, "if true, checking of files with generated code is disabled")
+	flags.BoolVar(&checker.WithoutGeneratedCode, "ignoregenerated", false, "if true, checking of files with generated code is disabled")
 	flags.BoolVar(&checker.Verbose, "verbose", false, "produce more verbose logging")
 
 	flags.BoolVar(&abspath, "abspath", false, "print absolute paths to files")
@@ -183,8 +182,11 @@ func parseFlags(checker *errcheck.Checker, args []string) ([]string, int) {
 	}
 	checker.Ignore = ignore
 
-	// ImportPaths normalizes paths and expands '...'
-	return gotool.ImportPaths(flags.Args()), exitCodeOk
+	paths := flags.Args()
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+	return paths, exitCodeOk
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -40,7 +40,7 @@ func TestMain(t *testing.T) {
 		bufChannel <- buf.String()
 	}()
 
-	exitCode := mainCmd([]string{"cmd name", "github.com/kisielk/errcheck/testdata"})
+	exitCode := mainCmd([]string{"cmd name", "-ignoretests", "github.com/kisielk/errcheck/testdata"})
 
 	w.Close()
 

--- a/main_test.go
+++ b/main_test.go
@@ -40,7 +40,7 @@ func TestMain(t *testing.T) {
 		bufChannel <- buf.String()
 	}()
 
-	exitCode := mainCmd([]string{"cmd name", "-ignoretests", "github.com/kisielk/errcheck/testdata"})
+	exitCode := mainCmd([]string{"cmd name", "github.com/kisielk/errcheck/testdata"})
 
 	w.Close()
 
@@ -54,7 +54,7 @@ func TestMain(t *testing.T) {
 		t.Errorf("Exit code is %d, expected %d", exitCode, exitUncheckedError)
 	}
 
-	expectUnchecked := 15
+	expectUnchecked := 28
 	if got := strings.Count(out, "UNCHECKED"); got != expectUnchecked {
 		t.Errorf("Got %d UNCHECKED errors, expected %d in:\n%s", got, expectUnchecked, out)
 	}

--- a/testdata/main_test.go
+++ b/testdata/main_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io/ioutil"
+	"math/rand"
+	mrand "math/rand"
+
+	"testing"
+)
+
+func TestFunc(tt *testing.T) {
+	// Single error return
+	_ = a() // BLANK
+	a()     // UNCHECKED
+
+	// Return another value and an error
+	_, _ = b() // BLANK
+	b()        // UNCHECKED
+
+	// Return a custom error type
+	_ = customError() // BLANK
+	customError()     // UNCHECKED
+
+	// Return a custom concrete error type
+	_ = customConcreteError()         // BLANK
+	customConcreteError()             // UNCHECKED
+	_, _ = customConcreteErrorTuple() // BLANK
+	customConcreteErrorTuple()        // UNCHECKED
+
+	// Return a custom pointer error type
+	_ = customPointerError()         // BLANK
+	customPointerError()             // UNCHECKED
+	_, _ = customPointerErrorTuple() // BLANK
+	customPointerErrorTuple()        // UNCHECKED
+
+	// Method with a single error return
+	x := t{}
+	_ = x.a() // BLANK
+	x.a()     // UNCHECKED
+
+	// Method call on a struct member
+	y := u{x}
+	_ = y.t.a() // BLANK
+	y.t.a()     // UNCHECKED
+
+	m1 := map[string]func() error{"a": a}
+	_ = m1["a"]() // BLANK
+	m1["a"]()     // UNCHECKED
+
+	// Additional cases for assigning errors to blank identifier
+	z, _ := b()    // BLANK
+	_, w := a(), 5 // BLANK
+
+	// Assign non error to blank identifier
+	_ = c()
+
+	_ = z + w // Avoid complaints about unused variables
+
+	// Type assertions
+	var i interface{}
+	s1 := i.(string)    // ASSERT
+	s1 = i.(string)     // ASSERT
+	s2, _ := i.(string) // ASSERT
+	s2, _ = i.(string)  // ASSERT
+	s3, ok := i.(string)
+	s3, ok = i.(string)
+	switch s4 := i.(type) {
+	case string:
+		_ = s4
+	}
+	_, _, _, _ = s1, s2, s3, ok
+
+	// Goroutine
+	go a()    // UNCHECKED
+	defer a() // UNCHECKED
+
+	b1 := bytes.Buffer{}
+	b2 := &bytes.Buffer{}
+	b1.Write(nil)
+	b2.Write(nil)
+	rand.Read(nil)
+	mrand.Read(nil)
+	sha256.New().Write([]byte{})
+
+	ioutil.ReadFile("main.go") // UNCHECKED
+
+	var emiw ErrorMakerInterfaceWrapper
+	emiw.MakeNilError()
+}


### PR DESCRIPTION
Use golang.org/x/tools/go/packages to load and type check packages.

This provides support for projects using go modules to also be able to
use errcheck.

errcheck can support packages that import "C", though there are
limitations when run with versions of Go that are earlier than Go 1.11.

There is also support in go/packages for finding the package that "contains" a file, so should be easy to add support for https://github.com/kisielk/errcheck/issues/106.