### PR TITLE
Support the -mod=vendor flag for using modules in a vendor directory

### DIFF
--- a/errcheck/errcheck.go
+++ b/errcheck/errcheck.go
@@ -187,6 +187,9 @@ type Checker struct {
 
 	// Tags are a list of build tags to use.
 	Tags []string
+
+	// The mod flag for go build.
+	Mod string
 }
 
 // loadPackages is used for testing.
@@ -197,10 +200,14 @@ var loadPackages = func(cfg *packages.Config, paths ...string) ([]*packages.Pack
 // LoadPackages loads all the packages in all the paths provided. It uses the
 // exclusions and build tags provided to by the user when loading the packages.
 func (c *Checker) LoadPackages(paths ...string) ([]*packages.Package, error) {
+	buildFlags := []string{fmtTags(c.Tags)}
+	if c.Mod != "" {
+		buildFlags = append(buildFlags, fmt.Sprintf("-mod=%s", c.Mod))
+	}
 	cfg := &packages.Config{
 		Mode:       packages.LoadAllSyntax,
 		Tests:      !c.Exclusions.TestFiles,
-		BuildFlags: []string{fmtTags(c.Tags)},
+		BuildFlags: buildFlags,
 	}
 	return loadPackages(cfg, paths...)
 }

--- a/main.go
+++ b/main.go
@@ -201,6 +201,8 @@ func parseFlags(checker *errcheck.Checker, args []string) ([]string, int) {
 	var excludeOnly bool
 	flags.BoolVar(&excludeOnly, "excludeonly", false, "Use only excludes from -exclude file")
 
+	flags.StringVar(&checker.Mod, "mod", "", "module download mode to use: readonly or vendor. See 'go help modules' for more.")
+
 	if err := flags.Parse(args[1:]); err != nil {
 		return nil, exitFatalError
 	}


### PR DESCRIPTION
We use go build -mod=vendor to use our vendored dependencies, and wanted to have errcheck build things the same way. So I added a little flag for it. 

Happy to add tests for it but wasn't sure what granularity you'd prefer the testing to be at.

Thanks for the great project!