### PR TITLE
Ignore comments and empty lines in excludes files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ An example of an exclude file is:
     io/ioutil.ReadFile
     io.Copy(*bytes.Buffer)
     io.Copy(os.Stdout)
+
+    // Sometimes we don't care if a HTTP request fails.
     (*net/http.Client).Do
 
 The exclude list is combined with an internal list for functions in the Go standard library that
@@ -70,6 +72,7 @@ In this case, add this line to your exclude file:
 example.com/yourpkg/vendor/example.net/fmt2.Println
 ```
 
+Empty lines and lines starting with `//` are ignored.
 
 ### The deprecated method
 

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -220,5 +221,38 @@ func TestParseFlags(t *testing.T) {
 		if e != c.error {
 			t.Errorf("%q: error got %q want %q", argsStr, e, c.error)
 		}
+	}
+}
+
+func TestReadExcludes(t *testing.T) {
+	expectedExcludes := map[string]bool{
+		"hello()": true,
+		"world()": true,
+	}
+	t.Logf("expectedExcludes: %#v", expectedExcludes)
+	excludes, err := readExcludes("testdata/excludes.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("excludes: %#v", excludes)
+	if !reflect.DeepEqual(expectedExcludes, excludes) {
+		t.Fatal("excludes did not match expectedExcludes")
+	}
+}
+
+func TestReadEmptyExcludes(t *testing.T) {
+	excludes, err := readExcludes("testdata/empty_excludes.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(excludes) != 0 {
+		t.Fatalf("expected empty excludes, got %#v", excludes)
+	}
+}
+
+func TestReadExcludesMissingFile(t *testing.T) {
+	_, err := readExcludes("testdata/missing_file")
+	if err == nil {
+		t.Fatal("expected non-nil err, got nil")
 	}
 }

--- a/testdata/excludes.txt
+++ b/testdata/excludes.txt
@@ -1,0 +1,5 @@
+// comment
+hello()
+
+//trickycomment()
+world()


### PR DESCRIPTION
I held off integrating errcheck into some projects for a while, because I really didn't want to add more false positives to my linters. The `-exclude` flag gives me a clean way to run `errcheck` and have everyone on the team easily use the same ignore settings. 

However, if we just add patterns to a file, over time it becomes very difficult to maintain. It isn't always obvious why we want to exclude a certain pattern. Comments and whitespace make it easier to organize the file in large projects.

Comments are also handy when debugging something, because you can temporarily comment something out and see if anything changes.

# Note

I wrote this to ignore lines prefixed with `//`. I'm not certain that's better than `#` because maybe it could conflict with future pattern recognition features you might add. But, I chose `//` anyway since that's what Go uses. I think it would make sense to change it, if someone thinks it might be a problem.