### PR TITLE
main: Use default GOMAXPROCS.

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/kisielk/errcheck/internal/errcheck"
@@ -107,8 +106,6 @@ func reportUncheckedErrors(e *errcheck.UncheckedErrors, verbose bool) {
 }
 
 func mainCmd(args []string) int {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	checker := errcheck.NewChecker()
 	paths, err := parseFlags(checker, args)
 	if err != exitCodeOk {


### PR DESCRIPTION
Since Go 1.5, the runtime sets GOMAXPROCS to NumCPU