### PR TITLE
Add -excludeonly flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ An example of an exclude file is:
     // Sometimes we don't care if a HTTP request fails.
     (*net/http.Client).Do
 
-The exclude list is combined with an internal list for functions in the Go standard library that
-have an error return type but are documented to never return an error.
+By default, the exclude list is combined with an internal list for functions in
+the Go standard library that have an error return type but are documented to never
+return an error. To disable the built-in exclude list, pass the `-excludeonly` flag.
+
+Run errcheck in `-verbose` mode to see the resulting list of added excludes.
 
 When using vendored dependencies, specify the full import path. For example:
 * Your project's import path is `example.com/yourpkg`

--- a/internal/errcheck/errcheck_test.go
+++ b/internal/errcheck/errcheck_test.go
@@ -407,8 +407,9 @@ func test(t *testing.T, f flags) {
 	checker := NewChecker()
 	checker.Asserts = asserts
 	checker.Blank = blank
-	checker.SetExclude(map[string]bool{
-		fmt.Sprintf("(%s.ErrorMakerInterface).MakeNilError", testPackage): true,
+	checker.AddExcludes(DefaultExcludes)
+	checker.AddExcludes([]string{
+		fmt.Sprintf("(%s.ErrorMakerInterface).MakeNilError", testPackage),
 	})
 	err := checker.CheckPackages(testPackage)
 	uerr, ok := err.(*UncheckedErrors)

--- a/main_test.go
+++ b/main_test.go
@@ -199,7 +199,7 @@ func TestParseFlags(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		checker := &errcheck.Checker{}
+		checker := errcheck.NewChecker()
 		p, e := parseFlags(checker, c.args)
 
 		argsStr := strings.Join(c.args, " ")

--- a/main_test.go
+++ b/main_test.go
@@ -225,9 +225,9 @@ func TestParseFlags(t *testing.T) {
 }
 
 func TestReadExcludes(t *testing.T) {
-	expectedExcludes := map[string]bool{
-		"hello()": true,
-		"world()": true,
+	expectedExcludes := []string{
+		"hello()",
+		"world()",
 	}
 	t.Logf("expectedExcludes: %#v", expectedExcludes)
 	excludes, err := readExcludes("testdata/excludes.txt")


### PR DESCRIPTION
Causes errcheck to ignore builtin exclude list
and use only the contents of -exclude file.
Default to false to maintain existing behaviour.

Resolves kisielk/errcheck#161