### PR TITLE
Remove CheckPaths

### DIFF
--- a/errcheck/errcheck.go
+++ b/errcheck/errcheck.go
@@ -86,8 +86,8 @@ type Result struct {
 type byName struct{ *Result }
 
 // Less reports whether the element with index i should sort before the element with index j.
-func (e byName) Less(i, j int) bool {
-	ei, ej := e.UncheckedErrors[i], e.UncheckedErrors[j]
+func (b byName) Less(i, j int) bool {
+	ei, ej := b.UncheckedErrors[i], b.UncheckedErrors[j]
 
 	pi, pj := ei.Pos, ej.Pos
 
@@ -102,6 +102,14 @@ func (e byName) Less(i, j int) bool {
 	}
 
 	return ei.Line < ej.Line
+}
+
+func (b byName) Swap(i, j int) {
+	b.UncheckedErrors[i], b.UncheckedErrors[j] = b.UncheckedErrors[j], b.UncheckedErrors[i]
+}
+
+func (b byName) Len() int {
+	return len(b.UncheckedErrors)
 }
 
 // Append appends errors to e. Append does not do any duplicate checking.
@@ -126,17 +134,7 @@ func (r *Result) Unique() *Result {
 }
 
 func (r *Result) Error() string {
-	return fmt.Sprintf("%d unchecked errors", r.Len())
-}
-
-// Len is the number of elements in the collection.
-func (r *Result) Len() int {
-	return len(r.UncheckedErrors)
-}
-
-// Swap swaps the elements with indexes i and j.
-func (r *Result) Swap(i, j int) {
-	r.UncheckedErrors[i], r.UncheckedErrors[j] = r.UncheckedErrors[j], r.UncheckedErrors[i]
+	return fmt.Sprintf("%d unchecked errors", len(r.UncheckedErrors))
 }
 
 // Exclusions define symbols and language elements that will be not checked

--- a/errcheck/errcheck_test.go
+++ b/errcheck/errcheck_test.go
@@ -449,7 +449,7 @@ func test(t *testing.T, f flags) {
 		t.Errorf("got %d errors, want %d", uerr.Len(), numErrors)
 	unchecked_loop:
 		for k := range uncheckedMarkers {
-			for _, e := range uerr.Errors {
+			for _, e := range uerr.UncheckedErrors {
 				if newMarker(e) == k {
 					continue unchecked_loop
 				}
@@ -459,7 +459,7 @@ func test(t *testing.T, f flags) {
 		if blank {
 		blank_loop:
 			for k := range blankMarkers {
-				for _, e := range uerr.Errors {
+				for _, e := range uerr.UncheckedErrors {
 					if newMarker(e) == k {
 						continue blank_loop
 					}
@@ -470,7 +470,7 @@ func test(t *testing.T, f flags) {
 		if asserts {
 		assert_loop:
 			for k := range assertMarkers {
-				for _, e := range uerr.Errors {
+				for _, e := range uerr.UncheckedErrors {
 					if newMarker(e) == k {
 						continue assert_loop
 					}
@@ -480,7 +480,7 @@ func test(t *testing.T, f flags) {
 		}
 	}
 
-	for i, err := range uerr.Errors {
+	for i, err := range uerr.UncheckedErrors {
 		m := marker{err.Pos.Filename, err.Pos.Line}
 		if !uncheckedMarkers[m] && !blankMarkers[m] && !assertMarkers[m] {
 			t.Errorf("%d: unexpected error: %v", i, err)

--- a/errcheck/errcheck_test.go
+++ b/errcheck/errcheck_test.go
@@ -190,14 +190,14 @@ package custom
 			}
 			uerr = uerr.Unique()
 			if test.numExpectedErrs == 0 {
-				if uerr.Len() != 0 {
+				if len(uerr.UncheckedErrors) != 0 {
 					t.Errorf("expected no errors, but got: %v", uerr)
 				}
 				return
 			}
 
-			if test.numExpectedErrs != uerr.Len() {
-				t.Errorf("expected: %d errors\nactual:   %d errors", test.numExpectedErrs, uerr.Len())
+			if test.numExpectedErrs != len(uerr.UncheckedErrors) {
+				t.Errorf("expected: %d errors\nactual:   %d errors", test.numExpectedErrs, len(uerr.UncheckedErrors))
 			}
 		})
 	}
@@ -300,14 +300,14 @@ require github.com/testlog v0.0.0
 			uerr = uerr.Unique()
 
 			if test.numExpectedErrs == 0 {
-				if uerr.Len() != 0 {
+				if len(uerr.UncheckedErrors) != 0 {
 					t.Errorf("expected no errors, but got: %v", uerr)
 				}
 				return
 			}
 
-			if test.numExpectedErrs != uerr.Len() {
-				t.Errorf("expected: %d errors\nactual:   %d errors", test.numExpectedErrs, uerr.Len())
+			if test.numExpectedErrs != len(uerr.UncheckedErrors) {
+				t.Errorf("expected: %d errors\nactual:   %d errors", test.numExpectedErrs, len(uerr.UncheckedErrors))
 			}
 		})
 	}
@@ -400,14 +400,14 @@ require github.com/testlog v0.0.0
 			uerr = uerr.Unique()
 
 			if test.numExpectedErrs == 0 {
-				if uerr.Len() != 0 {
+				if len(uerr.UncheckedErrors) != 0 {
 					t.Errorf("expected no errors, but got: %v", uerr)
 				}
 				return
 			}
 
-			if test.numExpectedErrs != uerr.Len() {
-				t.Errorf("expected: %d errors\nactual:   %d errors", test.numExpectedErrs, uerr.Len())
+			if test.numExpectedErrs != len(uerr.UncheckedErrors) {
+				t.Errorf("expected: %d errors\nactual:   %d errors", test.numExpectedErrs, len(uerr.UncheckedErrors))
 			}
 		})
 	}
@@ -445,8 +445,8 @@ func test(t *testing.T, f flags) {
 
 	uerr = uerr.Unique()
 
-	if uerr.Len() != numErrors {
-		t.Errorf("got %d errors, want %d", uerr.Len(), numErrors)
+	if len(uerr.UncheckedErrors) != numErrors {
+		t.Errorf("got %d errors, want %d", len(uerr.UncheckedErrors), numErrors)
 	unchecked_loop:
 		for k := range uncheckedMarkers {
 			for _, e := range uerr.UncheckedErrors {

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func checkPaths(c *errcheck.Checker, paths ...string) (*errcheck.Result, error) 
 
 	var wg sync.WaitGroup
 	result := &errcheck.Result{}
+	mu := &sync.Mutex{}
 	for i := 0; i < runtime.NumCPU(); i++ {
 		wg.Add(1)
 
@@ -162,7 +163,10 @@ func checkPaths(c *errcheck.Checker, paths ...string) (*errcheck.Result, error) 
 			defer wg.Done()
 			for pkg := range work {
 				logf("checking %s", pkg.Types.Path())
-				result.Append(c.CheckPackage(pkg))
+				r := c.CheckPackage(pkg)
+				mu.Lock()
+				result.Append(r)
+				mu.Unlock()
 			}
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func reportResult(e *errcheck.Result) {
 	if err != nil {
 		wd = ""
 	}
-	for _, uncheckedError := range e.Errors {
+	for _, uncheckedError := range e.UncheckedErrors {
 		pos := uncheckedError.Pos.String()
 		if !abspath {
 			newPos, err := filepath.Rel(wd, pos)

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func mainCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: failed to check packages: %s\n", err)
 		return exitFatalError
 	}
-	if result.Len() > 0 {
+	if len(result.UncheckedErrors) > 0 {
 		reportResult(result)
 		return exitUncheckedError
 	}


### PR DESCRIPTION
This commit removes the CheckPaths method of Checker. It also
adds a method called LoadPackages, and exports more of the logic
that errcheck uses to do aggregation.

The UncheckedErrors type has been renamed to Result, and the
CheckPackage function now returns a *Result instead of
[]UncheckedErrors.

Signed-off-by: Eric Chlebek <eric@sensu.io>