### PR TITLE
Add SelectorName in UncheckedError

### DIFF
--- a/errcheck/errcheck_test.go
+++ b/errcheck/errcheck_test.go
@@ -502,5 +502,8 @@ func test(t *testing.T, f flags) {
 		if !uncheckedMarkers[m] && !blankMarkers[m] && !assertMarkers[m] {
 			t.Errorf("%d: unexpected error: %v", i, err)
 		}
+		if err.SelectorName != "" && !strings.Contains(err.Line, err.SelectorName) {
+			t.Errorf("the line '%s' must contain the selector '%s'", err.Line, err.SelectorName)
+		}
 	}
 }


### PR DESCRIPTION
Added a `SelectorName` field in the `UncheckedError` struct to store the original func name.

We cannot integrate the `errchecker` linter with the `golangci-lint` tool without this changes, we have an additional exclude of `os.Stdout|Stderr.Write`, but the `fullName` function returns `(*os.File).Write` and ignoring `os.File` is not acceptable.
