### PR TITLE
Exclude (*io.Pipe{Read,Write}r).CloseWithError

### DIFF
--- a/errcheck/errcheck.go
+++ b/errcheck/errcheck.go
@@ -51,6 +51,10 @@ var (
 		"fmt.Fprintf(os.Stderr)",
 		"fmt.Fprintln(os.Stderr)",
 
+		// io
+		"(*io.PipeReader).CloseWithError",
+		"(*io.PipeWriter).CloseWithError",
+
 		// math/rand
 		"math/rand.Read",
 		"(*math/rand.Rand).Read",

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	mrand "math/rand"
@@ -147,6 +148,9 @@ func main() {
 	rand.Read(nil)
 	mrand.Read(nil)
 	sha256.New().Write([]byte{})
+	pr, pw := io.Pipe()
+	pr.CloseWithError(nil)
+	pw.CloseWithError(nil)
 
 	ioutil.ReadFile("main.go") // UNCHECKED
 


### PR DESCRIPTION
Exclude `(*io.PipeReader).CloseWithError` by default, as it is [documented to always return `nil`](https://github.com/golang/go/blob/go1.16.4/src/io/pipe.go#L146-L147).

Exclude `(*io.PipeWriter).CloseWithError` by default, as it is [documented to always return `nil`](https://github.com/golang/go/blob/go1.16.4/src/io/pipe.go#L176-L177).