### PR TITLE
Use "go install" instead of "go get" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ errcheck is a program for checking for unchecked errors in go programs.
 
 ## Install
 
-    go get -u github.com/kisielk/errcheck
+    go install github.com/kisielk/errcheck@latest
 
 errcheck requires Go 1.12 or newer, and depends on the package go/packages from the golang.org/x/tools repository.
 


### PR DESCRIPTION
See: https://go.dev/doc/go-get-install-deprecation
It's available since Go 1.16 and if you run "go get", it recommends using "go install" instead.