### PR TITLE
Calculate correct position with comments before the package keyword

### DIFF
--- a/errcheck/analyzer.go
+++ b/errcheck/analyzer.go
@@ -3,7 +3,6 @@ package errcheck
 import (
 	"fmt"
 	"go/ast"
-	"go/token"
 	"reflect"
 	"regexp"
 
@@ -66,7 +65,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 
 		for _, err := range v.errors {
 			pass.Report(analysis.Diagnostic{
-				Pos:     token.Pos(int(f.Pos()) + err.Pos.Offset),
+				Pos:     pass.Fset.File(f.Pos()).Pos(err.Pos.Offset),
 				Message: "unchecked error",
 			})
 		}

--- a/errcheck/analyzer_test.go
+++ b/errcheck/analyzer_test.go
@@ -1,0 +1,12 @@
+package errcheck
+
+import (
+	"golang.org/x/tools/go/analysis/analysistest"
+	"path/filepath"
+	"testing"
+)
+
+func TestAnalyzer(t *testing.T) {
+	packageDir := filepath.Join(analysistest.TestData(), "src/a/")
+	_ = analysistest.Run(t, packageDir, Analyzer)
+}

--- a/errcheck/testdata/src/a/main.go
+++ b/errcheck/testdata/src/a/main.go
@@ -1,3 +1,5 @@
+// ensure that the package keyword is not equal to file beginning
+// to test correct position calculations.
 package a
 
 import (


### PR DESCRIPTION
Detect the file beginning by using `pass.Fset.File(f.Pos())` instead of
assuming that `f.Pos()` is always the beginning of the file.

`f.Pos()` is the position of the package keyword which does not always correlate with the beginning of the file. `f.Pos()` is not the beginning of the file when there is for instance a
comment before the package, which can lead to wrong reportings of the
actual error position.