### PR TITLE
docs(README.md): Add abspath, mod, and ignoregenerated flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ takes no arguments.
 The `-blank` flag enables checking for assignments of errors to the
 blank identifier. It takes no arguments.
 
+The `-abspath` flag prints the absolute paths to files with unchecked errors.
+
+The `-mod` flag sets the module download mode to use: `readonly` or `vendor`.
+
+
+
 ### go/analysis
 
 The package provides `Analyzer` instance that can be used with
@@ -119,6 +125,8 @@ specified for it. To disable this, specify a regex that matches nothing:
 
 The `-ignoretests` flag disables checking of `_test.go` files. It takes
 no arguments.
+
+The `-ignoregenerated` flag disables checking of generated source code. It takes no arguments.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ The `-abspath` flag prints the absolute paths to files with unchecked errors.
 
 The `-mod` flag sets the module download mode to use: `readonly` or `vendor`.
 
-
-
 ### go/analysis
 
 The package provides `Analyzer` instance that can be used with


### PR DESCRIPTION
Noticed that some useful flags were not documented in the README.md. I've added the these in what I think are the relevant sections. I did a minimal explanation of the flags, but can expand on them.

I erred on the side of not expanding on -ignoregenerated for example because the regex might change in the future, and documentation tends to be a forgotten update...

Let me know if you need any changes, or anything else I can add to this PR.