### PR TITLE
Directly specify the needed fields when loading packages

### DIFF
--- a/errcheck/errcheck.go
+++ b/errcheck/errcheck.go
@@ -167,7 +167,7 @@ func (c *Checker) LoadPackages(paths ...string) ([]*packages.Package, error) {
 		buildFlags = append(buildFlags, fmt.Sprintf("-mod=%s", c.Mod))
 	}
 	cfg := &packages.Config{
-		Mode:       packages.LoadAllSyntax,
+		Mode:       packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo,
 		Tests:      !c.Exclusions.TestFiles,
 		BuildFlags: buildFlags,
 	}

--- a/errcheck/errcheck_test.go
+++ b/errcheck/errcheck_test.go
@@ -39,7 +39,7 @@ func init() {
 	assertMarkers = make(map[marker]bool)
 
 	cfg := &packages.Config{
-		Mode:  packages.LoadSyntax,
+		Mode:  packages.NeedSyntax | packages.NeedTypes,
 		Tests: true,
 	}
 	pkgs, err := packages.Load(cfg, testPackage)


### PR DESCRIPTION
Constants `LoadSyntax` and `LoadAllSyntax` are deprecated. See https://pkg.go.dev/golang.org/x/tools@v0.1.10/go/packages#pkg-constants.
