### PR TITLE
Fix errcheck issues in tests

### DIFF
--- a/errcheck/analyzer_test.go
+++ b/errcheck/analyzer_test.go
@@ -15,15 +15,15 @@ func TestAnalyzer(t *testing.T) {
 
 	t.Run("check blanks", func(t *testing.T) {
 		packageDir := filepath.Join(analysistest.TestData(), "src/blank/")
-		Analyzer.Flags.Set("blank", "true")
+		_ = Analyzer.Flags.Set("blank", "true")
 		_ = analysistest.Run(t, packageDir, Analyzer)
-		Analyzer.Flags.Set("blank", "false") // reset it
+		_ = Analyzer.Flags.Set("blank", "false") // reset it
 	})
 
 	t.Run("check asserts", func(t *testing.T) {
 		packageDir := filepath.Join(analysistest.TestData(), "src/assert/")
-		Analyzer.Flags.Set("assert", "true")
+		_ = Analyzer.Flags.Set("assert", "true")
 		_ = analysistest.Run(t, packageDir, Analyzer)
-		Analyzer.Flags.Set("assert", "false") // reset it
+		_ = Analyzer.Flags.Set("assert", "false") // reset it
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ func TestMain(t *testing.T) {
 
 	os.Stderr = saveStderr
 	os.Stdout = saveStdout
-	os.Chdir(saveCwd)
+	_ = os.Chdir(saveCwd)
 
 	out := <-bufChannel
 


### PR DESCRIPTION
This PR fixes the following:
```
main_test.go:51:10: Error return value of `os.Chdir` is not checked (errcheck)
        os.Chdir(saveCwd)
                ^
errcheck/analyzer_test.go:18:21: Error return value of `Analyzer.Flags.Set` is not checked (errcheck)
                Analyzer.Flags.Set("blank", "true")
                                  ^
errcheck/analyzer_test.go:20:21: Error return value of `Analyzer.Flags.Set` is not checked (errcheck)
                Analyzer.Flags.Set("blank", "false") // reset it
                                  ^
errcheck/analyzer_test.go:25:21: Error return value of `Analyzer.Flags.Set` is not checked (errcheck)
                Analyzer.Flags.Set("assert", "true")
```