### PR TITLE
fix: don't exclude fmt.Errorf

### DIFF
--- a/errcheck/excludes.go
+++ b/errcheck/excludes.go
@@ -7,56 +7,52 @@ import (
 	"strings"
 )
 
-var (
-	// DefaultExcludedSymbols is a list of symbol names that are usually excluded from checks by default.
-	//
-	// Note, that they still need to be explicitly copied to Checker.Exclusions.Symbols
-	DefaultExcludedSymbols = []string{
-		// bytes
-		"(*bytes.Buffer).Write",
-		"(*bytes.Buffer).WriteByte",
-		"(*bytes.Buffer).WriteRune",
-		"(*bytes.Buffer).WriteString",
+// DefaultExcludedSymbols is a list of symbol names that are usually excluded from checks by default.
+//
+// Note, that they still need to be explicitly copied to Checker.Exclusions.Symbols
+var DefaultExcludedSymbols = []string{
+	// bytes
+	"(*bytes.Buffer).Write",
+	"(*bytes.Buffer).WriteByte",
+	"(*bytes.Buffer).WriteRune",
+	"(*bytes.Buffer).WriteString",
 
-		// fmt
-		"fmt.Errorf",
-		"fmt.Print",
-		"fmt.Printf",
-		"fmt.Println",
-		"fmt.Fprint(*bytes.Buffer)",
-		"fmt.Fprintf(*bytes.Buffer)",
-		"fmt.Fprintln(*bytes.Buffer)",
-		"fmt.Fprint(*strings.Builder)",
-		"fmt.Fprintf(*strings.Builder)",
-		"fmt.Fprintln(*strings.Builder)",
-		"fmt.Fprint(os.Stderr)",
-		"fmt.Fprintf(os.Stderr)",
-		"fmt.Fprintln(os.Stderr)",
+	// fmt
+	"fmt.Print",
+	"fmt.Printf",
+	"fmt.Println",
+	"fmt.Fprint(*bytes.Buffer)",
+	"fmt.Fprintf(*bytes.Buffer)",
+	"fmt.Fprintln(*bytes.Buffer)",
+	"fmt.Fprint(*strings.Builder)",
+	"fmt.Fprintf(*strings.Builder)",
+	"fmt.Fprintln(*strings.Builder)",
+	"fmt.Fprint(os.Stderr)",
+	"fmt.Fprintf(os.Stderr)",
+	"fmt.Fprintln(os.Stderr)",
 
-		// io
-		"(*io.PipeReader).CloseWithError",
-		"(*io.PipeWriter).CloseWithError",
+	// io
+	"(*io.PipeReader).CloseWithError",
+	"(*io.PipeWriter).CloseWithError",
 
-		// math/rand
-		"math/rand.Read",
-		"(*math/rand.Rand).Read",
+	// math/rand
+	"math/rand.Read",
+	"(*math/rand.Rand).Read",
 
-		// strings
-		"(*strings.Builder).Write",
-		"(*strings.Builder).WriteByte",
-		"(*strings.Builder).WriteRune",
-		"(*strings.Builder).WriteString",
+	// strings
+	"(*strings.Builder).Write",
+	"(*strings.Builder).WriteByte",
+	"(*strings.Builder).WriteRune",
+	"(*strings.Builder).WriteString",
 
-		// hash
-		"(hash.Hash).Write",
-	}
-)
+	// hash
+	"(hash.Hash).Write",
+}
 
 // ReadExcludes reads an excludes file, a newline delimited file that lists
 // patterns for which to allow unchecked errors.
 //
 // Lines that start with two forward slashes are considered comments and are ignored.
-//
 func ReadExcludes(path string) ([]string, error) {
 	var excludes []string
 


### PR DESCRIPTION
... and run `gofumpt` on `excludes.go`, and update dependencies. (errcheck is failing for me, with error `package "reflect" without types was imported from "github.com/gnolang/gno/gnovm/pkg/gnolang"` -- I think this is due to type parameters, and updating x/tools fixes the issue).

The reason why I think we should not exclude fmt.Errorf is that, by making sure it is used, we catch wrong code like:

```
if err != nil {
	fmt.Errorf("invalid file: %w", err)
}
```

This is obviously meant to return the error, but it's not.

If the current behaviour is to be considered correct, then `errors.New` should also be excepted.