### PR TITLE
remove deprecated funcs usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ the the function call is excluded only if the type of the first argument is `TYP
 
 An example of an exclude file is:
 
-    io/ioutil.ReadFile
     io.Copy(*bytes.Buffer)
     io.Copy(os.Stdout)
+    os.ReadFile
 
     // Sometimes we don't care if a HTTP request fails.
     (*net/http.Client).Do

--- a/errcheck/errcheck_test.go
+++ b/errcheck/errcheck_test.go
@@ -2,7 +2,6 @@ package errcheck
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -120,7 +119,7 @@ package custom
 `
 	)
 
-	tmpGopath, err := ioutil.TempDir("", "testbuildtags")
+	tmpGopath, err := os.MkdirTemp("", "testbuildtags")
 	if err != nil {
 		t.Fatalf("unable to create testbuildtags directory: %v", err)
 	}
@@ -132,16 +131,16 @@ package custom
 		os.RemoveAll(tmpGopath)
 	}()
 
-	if err := ioutil.WriteFile(path.Join(testBuildTagsDir, "go.mod"), []byte("module github.com/testbuildtags"), 0644); err != nil {
+	if err := os.WriteFile(path.Join(testBuildTagsDir, "go.mod"), []byte("module github.com/testbuildtags"), 0644); err != nil {
 		t.Fatalf("Failed to write testbuildtags go.mod: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(testBuildTagsDir, "custom1.go"), []byte(testBuildCustom1Tag), 0644); err != nil {
+	if err := os.WriteFile(path.Join(testBuildTagsDir, "custom1.go"), []byte(testBuildCustom1Tag), 0644); err != nil {
 		t.Fatalf("Failed to write testbuildtags custom1: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(testBuildTagsDir, "custom2.go"), []byte(testBuildCustom2Tag), 0644); err != nil {
+	if err := os.WriteFile(path.Join(testBuildTagsDir, "custom2.go"), []byte(testBuildCustom2Tag), 0644); err != nil {
 		t.Fatalf("Failed to write testbuildtags custom2: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(testBuildTagsDir, "doc.go"), []byte(testDoc), 0644); err != nil {
+	if err := os.WriteFile(path.Join(testBuildTagsDir, "doc.go"), []byte(testDoc), 0644); err != nil {
 		t.Fatalf("Failed to write testbuildtags doc: %v", err)
 	}
 
@@ -229,7 +228,7 @@ require github.com/testlog v0.0.0
 	}`
 
 	// copy testvendor directory into directory for test
-	tmpGopath, err := ioutil.TempDir("", "testvendor")
+	tmpGopath, err := os.MkdirTemp("", "testvendor")
 	if err != nil {
 		t.Fatalf("unable to create testvendor directory: %v", err)
 	}
@@ -241,16 +240,16 @@ require github.com/testlog v0.0.0
 		os.RemoveAll(tmpGopath)
 	}()
 
-	if err := ioutil.WriteFile(path.Join(testVendorDir, "go.mod"), []byte(testVendorGoMod), 0755); err != nil {
+	if err := os.WriteFile(path.Join(testVendorDir, "go.mod"), []byte(testVendorGoMod), 0755); err != nil {
 		t.Fatalf("Failed to write testvendor go.mod: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(testVendorDir, "main.go"), []byte(testVendorMain), 0755); err != nil {
+	if err := os.WriteFile(path.Join(testVendorDir, "main.go"), []byte(testVendorMain), 0755); err != nil {
 		t.Fatalf("Failed to write testvendor main: %v", err)
 	}
 	if err := os.MkdirAll(path.Join(testVendorDir, "vendor/github.com/testlog"), 0755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(testVendorDir, "vendor/github.com/testlog/testlog.go"), []byte(testLog), 0755); err != nil {
+	if err := os.WriteFile(path.Join(testVendorDir, "vendor/github.com/testlog/testlog.go"), []byte(testLog), 0755); err != nil {
 		t.Fatalf("Failed to write testlog: %v", err)
 	}
 
@@ -336,7 +335,7 @@ require github.com/testlog v0.0.0
 	}`
 
 	// copy testvendor directory into directory for test
-	tmpGopath, err := ioutil.TempDir("", "testvendor")
+	tmpGopath, err := os.MkdirTemp("", "testvendor")
 	if err != nil {
 		t.Fatalf("unable to create testvendor directory: %v", err)
 	}
@@ -348,16 +347,16 @@ require github.com/testlog v0.0.0
 		os.RemoveAll(tmpGopath)
 	}()
 
-	if err := ioutil.WriteFile(path.Join(testVendorDir, "go.mod"), []byte(testVendorGoMod), 0755); err != nil {
+	if err := os.WriteFile(path.Join(testVendorDir, "go.mod"), []byte(testVendorGoMod), 0755); err != nil {
 		t.Fatalf("Failed to write testvendor go.mod: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(testVendorDir, "main.go"), []byte(testVendorMain), 0755); err != nil {
+	if err := os.WriteFile(path.Join(testVendorDir, "main.go"), []byte(testVendorMain), 0755); err != nil {
 		t.Fatalf("Failed to write testvendor main: %v", err)
 	}
 	if err := os.MkdirAll(path.Join(testVendorDir, "vendor/github.com/testlog"), 0755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(testVendorDir, "vendor/github.com/testlog/testlog.go"), []byte(testLog), 0755); err != nil {
+	if err := os.WriteFile(path.Join(testVendorDir, "vendor/github.com/testlog/testlog.go"), []byte(testLog), 0755); err != nil {
 		t.Fatalf("Failed to write testlog: %v", err)
 	}
 

--- a/errcheck/excludes.go
+++ b/errcheck/excludes.go
@@ -3,7 +3,7 @@ package errcheck
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -56,7 +56,7 @@ var DefaultExcludedSymbols = []string{
 func ReadExcludes(path string) ([]string, error) {
 	var excludes []string
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/errcheck/testdata/src/a/main.go
+++ b/errcheck/testdata/src/a/main.go
@@ -6,9 +6,9 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	mrand "math/rand"
+	"os"
 )
 
 func a() error {
@@ -150,7 +150,7 @@ func main() {
 	mrand.Read(nil)
 	sha256.New().Write([]byte{})
 
-	ioutil.ReadFile("main.go") // want "unchecked error"
+	os.ReadFile("main.go") // want "unchecked error"
 
 	var emiw ErrorMakerInterfaceWrapper
 	emiw.MakeNilError() // want "unchecked error"

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -5,9 +5,9 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	mrand "math/rand"
+	"os"
 )
 
 func a() error {
@@ -152,7 +152,7 @@ func main() {
 	pr.CloseWithError(nil)
 	pw.CloseWithError(nil)
 
-	ioutil.ReadFile("main.go") // UNCHECKED
+	os.ReadFile("main.go") // UNCHECKED
 
 	var emiw ErrorMakerInterfaceWrapper
 	emiw.MakeNilError()

--- a/testdata/main_test.go
+++ b/testdata/main_test.go
@@ -3,10 +3,9 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
-	"io/ioutil"
 	"math/rand"
 	mrand "math/rand"
-
+	"os"
 	"testing"
 )
 
@@ -84,7 +83,7 @@ func TestFunc(tt *testing.T) {
 	mrand.Read(nil)
 	sha256.New().Write([]byte{})
 
-	ioutil.ReadFile("main.go") // UNCHECKED
+	os.ReadFile("main.go") // UNCHECKED
 
 	var emiw ErrorMakerInterfaceWrapper
 	emiw.MakeNilError()


### PR DESCRIPTION
These funcs are deprecated and have replacements in stdlib as of Go 1.16 (ioutil.ReadFile) and as of Go 1.17 (ioutil.TempDir). Since this project requires Go 1.18 at least their usages can be safely removed.