### PR TITLE
exclude maphash methods that "never fail"

### DIFF
--- a/errcheck/excludes.go
+++ b/errcheck/excludes.go
@@ -47,6 +47,11 @@ var DefaultExcludedSymbols = []string{
 
 	// hash
 	"(hash.Hash).Write",
+
+	// hash/maphash
+	"(*hash/maphash.Hash).Write",
+	"(*hash/maphash.Hash).WriteByte",
+	"(*hash/maphash.Hash).WriteString",
 }
 
 // ReadExcludes reads an excludes file, a newline delimited file that lists

--- a/testdata/hash.go
+++ b/testdata/hash.go
@@ -1,0 +1,11 @@
+package main
+
+import "hash/maphash"
+
+
+func ignoreHashMapReturns() {
+	var hasher maphash.Hash
+	hasher.Write(nil)      // EXCLUDED
+	hasher.WriteByte(0)    // EXCLUDED
+	hasher.WriteString("") // EXCLUDED
+}

--- a/testdata/hash.go
+++ b/testdata/hash.go
@@ -1,7 +1,13 @@
 package main
 
-import "hash/maphash"
+import (
+	"crypto/sha256"
+	"hash/maphash"
+)
 
+func ignoreHashReturns() {
+	sha256.New().Write([]byte{}) // EXCLUDED
+}
 
 func ignoreHashMapReturns() {
 	var hasher maphash.Hash

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"fmt"
 	"io"
 	"math/rand"
@@ -147,7 +146,6 @@ func main() {
 	b2.Write(nil)
 	rand.Read(nil)
 	mrand.Read(nil)
-	sha256.New().Write([]byte{})
 	pr, pw := io.Pipe()
 	pr.CloseWithError(nil)
 	pw.CloseWithError(nil)


### PR DESCRIPTION
These methods [are documented](https://pkg.go.dev/hash/maphash#Hash.Write) to "never fail", so it should be okay to ignore the return values.

`hash.Hash` is already excluded, but unlike the other subpkgs of `hash`, `hash/maphash` doesn't follow the convention of using a `New() hash.Hash` constructor; instead it exposes a struct `*maphash.Hash`,  who's methods are called directly.

Since this is part of the standard library and likely to be called in this way, it seemed appropriate to add them to the default exclusion list.
You think so?