### PR TITLE
Bump GitHub action workflows

### DIFF
--- a/.github/workflows/errcheck.yml
+++ b/.github/workflows/errcheck.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ["1.18.x", "1.19.x", "1.20.x", "1.21.x", "1.22.x"]
+        go: ["1.18.x", "1.19.x", "1.20.x", "1.21.x", "1.22.x", "1.23.x"]
     name: go ${{ matrix.go }}
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
     - name: Build


### PR DESCRIPTION
This PR bumps GitHub action workflow to their latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/kisielk/errcheck/actions/runs/11356368818).