### PR TITLE
Update to golang.org/x/tools v0.30.0 for go1.24

### DIFF
--- a/.github/workflows/errcheck.yml
+++ b/.github/workflows/errcheck.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ["1.18.x", "1.19.x", "1.20.x", "1.21.x", "1.22.x", "1.23.x"]
+        go: ["1.22.x", "1.23.x", "1.24.x"]
     name: go ${{ matrix.go }}
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ errcheck is a program for checking for unchecked errors in Go code.
 
     go install github.com/kisielk/errcheck@latest
 
-errcheck requires Go 1.18 or newer.
+errcheck requires Go 1.22 or newer.
 
 ## Use
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/kisielk/errcheck
 
-go 1.18
+go 1.22
 
-require golang.org/x/tools v0.17.0
+require golang.org/x/tools v0.30.0
 
-require golang.org/x/mod v0.14.0 // indirect
+require (
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kisielk/errcheck
 
-go 1.22
+go 1.22.0
 
 require golang.org/x/tools v0.30.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
-golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
-golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
-golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=


### PR DESCRIPTION
With go1.24 and errcheck v1.8.0 get errors like:

`internal error: package "math" without types was imported from ...`

Updated `golang.org/x/tools` to latest and now works fine with go1.24

Minimum Go version now 1.22 because that is required by the updated `golang.org/x/tools`