### PR TITLE
exclude crypto/rand.Read by default

### DIFF
--- a/errcheck/excludes.go
+++ b/errcheck/excludes.go
@@ -17,6 +17,9 @@ var DefaultExcludedSymbols = []string{
 	"(*bytes.Buffer).WriteRune",
 	"(*bytes.Buffer).WriteString",
 
+	// crypto
+	"crypto/rand.Read", // https://github.com/golang/go/issues/66821
+
 	// fmt
 	"fmt.Print",
 	"fmt.Printf",

--- a/testdata/crypto_rand.go
+++ b/testdata/crypto_rand.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"crypto/rand"
+)
+
+func ignoreRandReaderReturns() {
+	buf := make([]byte, 128)
+	rand.Read(buf) // EXCLUDED
+}


### PR DESCRIPTION
Also mentioned in docs with examples. See - https://pkg.go.dev/crypto/rand#Read