### PR TITLE
Exclude crypto/sha3.Read and crypto/sha3.Write by default

### DIFF
--- a/errcheck/excludes.go
+++ b/errcheck/excludes.go
@@ -50,6 +50,9 @@ var DefaultExcludedSymbols = []string{
 
 	// hash
 	"(hash.Hash).Write",
+	"(*crypto/sha3.SHA3).Write",
+	"(*crypto/sha3.SHAKE).Read",
+	"(*crypto/sha3.SHAKE).Write",
 
 	// hash/maphash
 	"(*hash/maphash.Hash).Write",

--- a/testdata/sha3.go
+++ b/testdata/sha3.go
@@ -1,0 +1,19 @@
+//go:build go1.24
+
+package main
+
+import (
+	"crypto/sha3"
+)
+
+func ignoreSHA3() {
+	h := sha3.New256()
+	h.Write([]byte("hello world")) // EXCLUDED
+}
+
+func ignoreSHA3_SHAKE() {
+	h := sha3.NewSHAKE256()
+	h.Write([]byte("hello world")) // EXCLUDED
+	buf := make([]byte, 32)
+	h.Read(buf) // EXCLUDED
+}


### PR DESCRIPTION
Hi,

I am using https://pkg.go.dev/crypto/sha3, which was added in Go 1.24.
Unlike other packages (e.g. crypto/sha256), crypto/sha3 returns `*crypto/sha3.SHA3` or `*crypto/sha3.SHAKE` instead of `hash.Hash`.
This causes errcheck to report a false positive.
Therefore, I added "crypto/sha3" to the exclude list.
