### PR TITLE
Support excludes for functions with type parameters

### DIFF
--- a/errcheck/errcheck.go
+++ b/errcheck/errcheck.go
@@ -262,7 +262,7 @@ type visitor struct {
 // If the call does not include a selector (like if it is a plain "f()" function call)
 // then the final return value will be false.
 func (v *visitor) selectorAndFunc(call *ast.CallExpr) (*ast.SelectorExpr, *types.Func, bool) {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
+	sel, ok := baseCallExpr(call.Fun).(*ast.SelectorExpr)
 	if !ok {
 		return nil, nil, false
 	}
@@ -420,14 +420,15 @@ func (v *visitor) ignoreCall(call *ast.CallExpr) bool {
 	// Currently only supports simple expressions:
 	//     1. f()
 	//     2. x.y.f()
+	//     3. x.y[T]() or x.y[T1, T2]()
 	var id *ast.Ident
-	switch exp := call.Fun.(type) {
+	switch exp := baseCallExpr(call.Fun).(type) {
 	case *ast.Ident:
 		id = exp
 	case *ast.SelectorExpr:
 		id = exp.Sel
 	default:
-		// eg: *ast.SliceExpr, *ast.IndexExpr
+		// eg: *ast.SliceExpr
 	}
 
 	if id == nil {
@@ -448,6 +449,24 @@ func (v *visitor) ignoreCall(call *ast.CallExpr) bool {
 	}
 
 	return false
+}
+
+// baseCallExpr returns the underlying function expression for a call. Type
+// arguments and parentheses wrap the selector/name in additional AST nodes, so
+// matching call.Fun directly would miss forms like errors.AsType[T](err).
+func baseCallExpr(fun ast.Expr) ast.Expr {
+	for {
+		switch f := fun.(type) {
+		case *ast.IndexExpr:
+			fun = f.X
+		case *ast.IndexListExpr:
+			fun = f.X
+		case *ast.ParenExpr:
+			fun = f.X
+		default:
+			return fun
+		}
+	}
 }
 
 // nonVendoredPkgPath returns the unvendored version of the provided package

--- a/errcheck/errcheck_test.go
+++ b/errcheck/errcheck_test.go
@@ -200,6 +200,91 @@ func TestWhitelist(t *testing.T) {
 
 }
 
+func TestTypeParameterizedFunctionExclude(t *testing.T) {
+	const testGoMod = `module typeparamtest
+
+go 1.18
+`
+	const testLib = `package errtypes
+
+func As[E error](err error) (E, bool) {
+	e, ok := err.(E)
+	return e, ok
+}
+`
+	const testMain = `package main
+
+import "typeparamtest/errtypes"
+
+type MyError string
+
+func (e MyError) Error() string { return string(e) }
+
+func main() {
+	var err error = MyError("test")
+	_, ok := errtypes.As[MyError](err)
+	_ = ok
+}
+`
+	tmpDir := t.TempDir()
+	libDir := path.Join(tmpDir, "errtypes")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(tmpDir, "go.mod"), []byte(testGoMod), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(libDir, "errtypes.go"), []byte(testLib), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(tmpDir, "main.go"), []byte(testMain), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origLoadPackages := loadPackages
+	t.Cleanup(func() { loadPackages = origLoadPackages })
+
+	loadPackages = func(cfg *packages.Config, paths ...string) ([]*packages.Package, error) {
+		cfg.Dir = tmpDir
+		return packages.Load(cfg, paths...)
+	}
+
+	t.Run("detected", func(t *testing.T) {
+		var checker Checker
+		checker.Exclusions.BlankAssignments = false
+		pkgs, err := checker.LoadPackages("typeparamtest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := Result{}
+		for _, pkg := range pkgs {
+			result.Append(checker.CheckPackage(pkg))
+		}
+		result = result.Unique()
+		if len(result.UncheckedErrors) != 1 {
+			t.Errorf("expected 1 error, got %d: %v", len(result.UncheckedErrors), result.UncheckedErrors)
+		}
+	})
+
+	t.Run("excluded", func(t *testing.T) {
+		var checker Checker
+		checker.Exclusions.BlankAssignments = false
+		checker.Exclusions.Symbols = []string{"typeparamtest/errtypes.As"}
+		pkgs, err := checker.LoadPackages("typeparamtest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := Result{}
+		for _, pkg := range pkgs {
+			result.Append(checker.CheckPackage(pkg))
+		}
+		result = result.Unique()
+		if len(result.UncheckedErrors) != 0 {
+			t.Errorf("expected 0 errors, got %d: %v", len(result.UncheckedErrors), result.UncheckedErrors)
+		}
+	})
+}
+
 func TestIgnore(t *testing.T) {
 	const testVendorGoMod = `module github.com/testvendor
 


### PR DESCRIPTION
Go 1.26 added `errors.AsType`, which can appears as:

```go
_, ok := errors.AsType[*SomeError](err)
```

An exclusion file entry for `errors.AsType` currently does not match this form, as described in #274. This change unwraps type parameters and parenthesized expressions before matching selectors or identifiers for exclusions.

Not sure if exclusions are the preferred long-term fix here, or if `errors.AsType` should get more targeted handling. I kept this change narrow, but happy to adjust if there's a better direction :slightly_smiling_face: