### PR TITLE
Upgraded tools to latest, minimum go version to 1.25

### DIFF
--- a/.github/workflows/errcheck.yml
+++ b/.github/workflows/errcheck.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ["1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x"]
+        go: ["1.25.x", "1.26.x"]
     name: go ${{ matrix.go }}
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For such analysis and more, please see [staticcheck](https://staticcheck.dev/).
 
     go install github.com/kisielk/errcheck@latest
 
-errcheck requires Go 1.22 or newer.
+errcheck requires Go 1.25 or newer.
 
 ## Use
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/kisielk/errcheck
 
-go 1.22.0
+go 1.25.0
 
-require golang.org/x/tools v0.30.0
+require golang.org/x/tools v0.44.0
 
 require (
-	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/sync v0.11.0 // indirect
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
-golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
-golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
-golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
-golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=


### PR DESCRIPTION
With the release of Go 1.26, Go versions of 1.24 and earlier are no longer supported. Additionally, with the golang.org/x/tools version being at v0.30.0 I was having issues running this with some libraries that use Go 1.24 (namely https://github.com/stephenafamo/bob, was getting "package ... without types was imported" when running errcheck).

Updated the tools version to latest, minimum supported version of go to 1.25 and updated the README accordingly.