### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/errcheck.yml
+++ b/.github/workflows/errcheck.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/kisielk/errcheck/security/code-scanning/1](https://github.com/kisielk/errcheck/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the token is least-privileged regardless of repo/org defaults.

Best fix here: add `permissions: contents: read` at the workflow root (near `on:`), which applies to all jobs unless overridden. This preserves existing functionality (`actions/checkout` and Go build/test only need read access) and documents intent.

File to edit:
- `.github/workflows/errcheck.yml`  
Change region:
- Insert `permissions:` block between trigger section and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
